### PR TITLE
Read the body of response message when HTTP response code is >=400 (serv...

### DIFF
--- a/overthere/src/main/java/com/xebialabs/overthere/cifs/winrm/connector/JdkHttpConnector.java
+++ b/overthere/src/main/java/com/xebialabs/overthere/cifs/winrm/connector/JdkHttpConnector.java
@@ -78,7 +78,14 @@ public class JdkHttpConnector implements HttpConnector {
 			bw.flush();
 			bw.close();
 
-			InputStream is = urlConnection.getInputStream();
+			InputStream is;
+			if (con.getResponseCode() >= 400) {
+			     /* Read error response */
+			    is = httpConn.getErrorStream();
+			} else {
+			    is = httpConn.getInputStream();
+			}
+			
 			Writer writer = new StringWriter();
 			try {
 				int n;


### PR DESCRIPTION
...er reported an error).

According to winrm specification :
A client SHOULD immediately issue a Receive message when a command is launched, whether or not it will be sending input using Send messages. To prevent deadlock, livelock, or time-out situations, the server may return Receive messages with empty string content, but typically it will delay responding until output is available, providing that wsman:OperationTimeout rules are not violated. If no output is available before the wsman:OperationTimeout expires, the server MUST return a WSManFault with the Code attribute equal to "2150858793". When the client receives this fault, it SHOULD issue another Receive request. The client SHOULD continue to issue Receive messages as soon as the previous ReceiveResponse has been received.

The WS-Management specification allows servers to specify additional fault details as part of the SOAP fault it generates. In certain cases client must read and react based on provided fault code. Basicaly this is the first step for resolving the issue:
The second step will be to modify the WinRmClient to resend Recieve message if the code is "2150858793".
