### PR TITLE
Correct the pattern used for ls commands (correctly handles ending '.', '+' or '@')

### DIFF
--- a/src/main/java/com/xebialabs/overthere/ssh/SshScpFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshScpFile.java
@@ -58,7 +58,7 @@ import static java.lang.String.format;
  */
 class SshScpFile extends SshFile<SshScpConnection> {
 
-    private static final String PERMISSIONS_TOKEN_PATTERN = "[d\\-]([r\\-][w\\-][xst\\-]){3}\\@?";
+    private static final String PERMISSIONS_TOKEN_PATTERN = "[d\\-]([r\\-][w\\-][xst\\-]){3}[\\@\\.\\+]*";
 
     private static Pattern permissionsTokenPattern = Pattern.compile(PERMISSIONS_TOKEN_PATTERN);
 


### PR DESCRIPTION
The pattern used to check permissions from the return of the ls command can only handle :
- drwxrwxrwx
- drwxrwxrwx@

It should be able to handle these :
- drwxrwxrwx (normal)
- drwxrwxrwx@ (Mac OS X)
- drwxrwxrwx. (SELinux)
- drwxrwxrwx+  (ACLs)
