### PR TITLE
homeDirSafe option for startProcess() method

### DIFF
--- a/src/main/java/com/xebialabs/overthere/OverthereConnection.java
+++ b/src/main/java/com/xebialabs/overthere/OverthereConnection.java
@@ -114,6 +114,8 @@ public interface OverthereConnection extends Closeable {
      *         connection.
      */
     OverthereProcess startProcess(CmdLine commandLine);
+    
+    OverthereProcess startProcess(CmdLine commandLine, boolean homeDirSafe);
 
     /**
      * Checks whether a process can be started on this connection.

--- a/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
+++ b/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
@@ -392,6 +392,13 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
     public OverthereProcess startProcess(CmdLine commandLine) {
         throw new UnsupportedOperationException("Cannot start a process on " + this);
     }
+    
+    
+    public OverthereProcess startProcess(CmdLine commandLine,
+        boolean homeDirSafe) {
+      throw new UnsupportedOperationException("Cannot start a process on " + this);
+    }
+    
 
     /**
      * Checks whether a process can be started on this connection.
@@ -410,5 +417,6 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
     public abstract String toString();
 
     private static Logger logger = LoggerFactory.getLogger(BaseOverthereConnection.class);
+
 
 }


### PR DESCRIPTION
LDAP backed Unix hosts might not allow users to run commands if they
are not logged in to that host previously since they don't have a home
directory yet. This option, when set to true, creates a shell before
running a command and immediately closes it to trigger home directory
creation.
