### PR TITLE
Fixed SshSudoFile.equals

### DIFF
--- a/src/main/java/com/xebialabs/overthere/ssh/SshSudoFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSudoFile.java
@@ -48,7 +48,7 @@ class SshSudoFile extends SshScpFile {
 
     /**
      * Constructs a SshSudoHostFile
-     * 
+     *
      * @param connection
      *            the connection connected to the host
      * @param remotePath
@@ -187,7 +187,7 @@ class SshSudoFile extends SshScpFile {
         if (chmodResult != 0) {
             String errorMessage = chmodCapturedOutput.getOutput();
             throw new RuntimeIOException("Cannot grant group and other read and execute permissions (chmod -R go+rX) to file " + tempFile
-                + " before download: " + errorMessage);
+                    + " before download: " + errorMessage);
         }
     }
 
@@ -218,6 +218,19 @@ class SshSudoFile extends SshScpFile {
 
     boolean isTempFile() {
         return isTempFile;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof SshSudoFile)) {
+            return false;
+        }
+        return  super.equals(obj) && isTempFile == ((SshSudoFile)obj).isTempFile;
+    }
+
+    @Override
+    public int hashCode() {
+        return path.hashCode() + Boolean.valueOf(isTempFile).hashCode();
     }
 
     private Logger logger = LoggerFactory.getLogger(SshSudoFile.class);

--- a/src/test/java/com/xebialabs/overthere/ssh/SshSudoFileTest.java
+++ b/src/test/java/com/xebialabs/overthere/ssh/SshSudoFileTest.java
@@ -1,0 +1,37 @@
+package com.xebialabs.overthere.ssh;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+
+public class SshSudoFileTest {
+
+    public static final String REMOTE_PATH = "/tmp/file.txt";
+    private SshSudoConnection connection;
+
+    @BeforeClass
+    public void setup() {
+        connection = mock(SshSudoConnection.class);
+    }
+
+    @Test
+    public void shouldNotBeEqualWhenOneIsTempAndAnotherIsNot() {
+        SshSudoFile f1 = new SshSudoFile(connection, REMOTE_PATH, false);
+        SshSudoFile f2 = new SshSudoFile(connection, REMOTE_PATH, true);
+        assertThat(f1, is(not(f2)));
+        assertThat(f1.hashCode(), is(not(f2.hashCode())));
+    }
+
+    @Test
+    public void shouldBeEqual() {
+        SshSudoFile f1 = new SshSudoFile(connection, REMOTE_PATH, false);
+        SshSudoFile f2 = new SshSudoFile(connection, REMOTE_PATH, false);
+        assertThat(f1, is(f2));
+        assertThat(f1.hashCode(), is(f2.hashCode()));
+    }
+
+}


### PR DESCRIPTION
This fix is not really needed for DEPLOYITPB-4656, but it fixes the contract, which is currently broken.
