### PR TITLE
Add refreshKrb5Config=true option to Kerberos JAAS configuration

### DIFF
--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/KerberosJaasConfiguration.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/KerberosJaasConfiguration.java
@@ -20,6 +20,7 @@ class KerberosJaasConfiguration extends Configuration {
         options.put("useTicketCache", "false");
         options.put("useKeyTab", "false");
         options.put("doNotPrompt", "false");
+        options.put("refreshKrb5Config", "true");
         if (debug) {
             options.put("debug", "true");
         }


### PR DESCRIPTION
Allows system properties to be used to specify KDC/Realm name and can be changed.

Alternately, the WinrmClient could be changed to support specifying a custom configuration class for specific needs.  This change seemed simplest. I don't think it would have much effect for people who don't need it but it allows some people to use the java System properties to specify KDC/realm, and then later modify those system properties.
