### PR TITLE
Add ability to use an alternate password for sudo password prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,12 @@ The SSH protocol implementation of Overthere defines a number of additional conn
 	<strong>N.B.:</strong> This connection option is only applicable for the <strong>SUDO</strong> and <strong>INTERACTIVE_SUDO</strong> connection types.</td>
 </tr>
 <tr>
+	<th align="left" valign="top"><a name="ssh_sudoInteractivePassword"></a>sudoInteractivePassword</th>
+	<td>Specifies the password to use for keyboard-interactive password prompts resulting from executing commands having a <a href="#ssh_sudoCommandPrefix"><strong>sudoCommandPrefix</strong></a> that require a different password to that used to establish the connection. Example <code>su - privilegeduser -c 'start server1'</code>.  When empty, the default password used for making the connection is used.
+	<br/>
+	<strong>N.B.:</strong> This connection option is only applicable for the <strong>INTERACTIVE_SUDO</strong> connection type.</td>
+</tr>
+<tr>
 	<th align="left" valign="top"><a name="ssh_privateKeyFile"></a>privateKeyFile</th>
 	<td>The RSA private key file to use when connecting to the remote host. When this connection option is specified, the <strong>password</strong> connection option is ignored.</td>
 </tr>
@@ -280,7 +286,7 @@ The SSH protocol implementation of Overthere defines a number of additional conn
 </tr>
 <tr>
 	<th align="left" valign="top"><a name="ssh_sudoCommandPrefix"></a>sudoCommandPrefix</th>
-	<td>The command to prefix to the command to be executed to execute it as <strong>sudoUsername</strong>. The string <code>{0}</code> is replaced with the value of <strong>sudoUsername</strong>. The default value is <code>sudo -u {0}</code>.
+	<td>The command to prefix to the command to be executed to execute it as <strong>sudoUsername</strong>. The string <code>{0}</code> is replaced with the value of <strong>sudoUsername</strong>. The default value is <code>sudo -u {0}</code>. 
 	<br/>
 	<strong>N.B.:</strong> This connection option is only applicable for the <strong>SUDO</strong> and <strong>INTERACTIVE_SUDO</strong> connection types.</td>
 </tr>
@@ -310,7 +316,7 @@ The SSH protocol implementation of Overthere defines a number of additional conn
 </tr>
 <tr>
 	<th align="left" valign="top"><a name="ssh_sudoQuoteCommand"></a>sudoQuoteCommand</th>
-	<td>If set to <code>true</code>, the original command is added as one argument to the prefix configured with the <code>sudoCommandPrefix</code> connection option. This has the result of quoting the original command, which is needed for commands like <code>su</code>. Compare <code>sudo -u privilegeduser start server1</code> to <code>su privilegeduser 'start server1'</code>. The default value is <code>false</code>.
+	<td>If set to <code>true</code>, the original command is added as one argument to the prefix configured with the <code>sudoCommandPrefix</code> connection option. This has the result of quoting the original command, which is needed for commands like <code>su</code>. Compare <code>sudo -u privilegeduser start server1</code> to <code>su privilegeduser -c 'start server1'</code>. The default value is <code>false</code>.
 	<br/>
 	<strong>N.B.:</strong> This connection option is only applicable for the <strong>SUDO</strong> and <strong>INTERACTIVE_SUDO</strong> connection types.</td>
 </tr>

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnectionBuilder.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnectionBuilder.java
@@ -126,6 +126,12 @@ public class SshConnectionBuilder implements OverthereConnectionBuilder {
     public static final String SUDO_USERNAME = "sudoUsername";
 
     /**
+     * Connection option (String) that specifies an alternate password to use for the password prompt for
+     * {@link SshConnectionType#INTERACTIVE_SUDO INTERACTIVE_SUDO} SSH connections. When empty, the default password used for making the connection is used.
+     */
+    public static final String SUDO_INTERACTIVE_PASSWORD = "sudoInteractivePassword";
+
+    /**
      * Connection option (Boolean) that specifies whether or not to explicitly change the permissions with chmod -R
      * go+rX after uploading a file or directory with scp. Also see {@link #SUDO_OVERRIDE_UMASK_COMMAND}.
      */


### PR DESCRIPTION
This makes it possible for Overthere to support  `su` commands (where the password to be entered is not the password of the connecting user).
