### PR TITLE
Issue 97: Removing check for user@domain syntax in WINRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,9 +438,10 @@ The CIFS protocol implementation of Overthere uses the [CIFS protocol](http://en
 ### Domain accounts
 Windows domain accounts are supported by the __WINRM_INTERNAL__, __WINRM_NATIVE__ and __TELNET__ connection types, but the syntax of the username is different:
 
-* For the __WINRM_INTERNAL__ and __WINRM_NATIVE__ connection types, domain accounts must be specified using the new-style domain syntax, e.g. `USER@FULL.DOMAIN`.
-* For the __TELNET__ connection type, domain accounts must be specified using the old-style domain synyax, e.g `DOMAIN\USER`.
-* For both connection types, local accounts must be specified without an at-sign (`@`) or a backslash (`\`).
+* For the __WINRM_INTERNAL__ connection type, domain accounts must be specified using the new-style domain syntax, e.g. `USER@FULL.DOMAIN`.
+* For the __TELNET__ connection type, domain accounts must be specified using the old-style domain syntax, e.g `DOMAIN\USER`.
+* For the __WINRM_NATIVE__ connection type, domain accounts may be specified using either the new-style (`USER@FULL.DOMAIN`) or old-style (`DOMAIN\USER`) domain syntax.
+* For all three connection types, local accounts must be specified without an at-sign (`@`) or a backslash (`\`).
 
 __N.B.:__ When using domain accounts with the __WINRM_INTERNAL__ connection type, the Kerberos subsystem of the Java Virtual Machine must be configured correctly. Please read the section on how to set up Kerberos [for the source host](#cifs_host_setup_krb5) and [the remote hosts](#cifs_host_setup_spn).
 

--- a/src/main/java/com/xebialabs/overthere/cifs/winrs/CifsWinrsConnection.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrs/CifsWinrsConnection.java
@@ -66,7 +66,6 @@ public class CifsWinrsConnection extends CifsConnection {
     public CifsWinrsConnection(String type, ConnectionOptions options, AddressPortMapper mapper) {
         super(type, options, mapper, true);
         checkArgument(os == WINDOWS, "Cannot start a " + CIFS_PROTOCOL + ":%s connection to a machine that is not running Windows", cifsConnectionType.toString().toLowerCase());
-        checkArgument(!username.contains("\\"), "Cannot start a " + CIFS_PROTOCOL + ":%s connection with an old-style Windows domain account [%s], use USER@DOMAIN instead.", cifsConnectionType.toString().toLowerCase(), username);
         checkArgument(mapper instanceof DefaultAddressPortMapper, "Cannot create a " + CIFS_PROTOCOL + ":%s connection when connecting through a SSH jumpstation", cifsConnectionType.toString().toLowerCase());
 
         this.options = options;

--- a/src/test/java/com/xebialabs/overthere/cifs/winrs/CifsWinRsConnectionTest.java
+++ b/src/test/java/com/xebialabs/overthere/cifs/winrs/CifsWinRsConnectionTest.java
@@ -57,10 +57,10 @@ public class CifsWinRsConnectionTest {
         new CifsWinrsConnection(CIFS_PROTOCOL, options, INSTANCE);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     @Assumption(methods = "onWindows")
     @SuppressWarnings("resource")
-    public void shouldNotSupportOldStyleDomainAccount() {
+    public void shouldSupportOldStyleDomainAccount() {
         options.set(USERNAME, "domain\\user");
         new CifsWinrsConnection(CIFS_PROTOCOL, options, INSTANCE);
     }


### PR DESCRIPTION
WINRS supports old-style DOMAIN\user syntax, too.
