### PR TITLE
Adding unit tests for WINRS

### DIFF
--- a/src/test/java/com/xebialabs/overthere/cifs/winrs/CifsWinRsConnectionTest.java
+++ b/src/test/java/com/xebialabs/overthere/cifs/winrs/CifsWinRsConnectionTest.java
@@ -24,6 +24,7 @@ package com.xebialabs.overthere.cifs.winrs;
 
 import com.xebialabs.overthere.ConnectionOptions;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static com.xebialabs.overthere.ConnectionOptions.*;
@@ -31,6 +32,7 @@ import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.*;
 import static com.xebialabs.overthere.cifs.CifsConnectionType.WINRM_NATIVE;
 import static com.xebialabs.overthere.util.DefaultAddressPortMapper.INSTANCE;
+import static com.xebialabs.overthere.util.TestUtils.*;
 
 public class CifsWinRsConnectionTest {
 
@@ -47,25 +49,29 @@ public class CifsWinRsConnectionTest {
         options.set(ADDRESS, "localhost");
     }
 
-    @Test
+    @Test(dataProvider = "runOnlyOnWindows")
     @SuppressWarnings("resource")
     public void shouldSupportNewStyleDomainAccount() {
         options.set(USERNAME, "user@domain.com");
         new CifsWinrsConnection(CIFS_PROTOCOL, options, INSTANCE);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(dataProvider = "runOnlyOnWindows", expectedExceptions = IllegalArgumentException.class)
     @SuppressWarnings("resource")
     public void shouldNotSupportOldStyleDomainAccount() {
         options.set(USERNAME, "domain\\user");
         new CifsWinrsConnection(CIFS_PROTOCOL, options, INSTANCE);
     }
 
-    @Test
+    @Test(dataProvider = "runOnlyOnWindows")
     @SuppressWarnings("resource")
     public void shouldSupportDomainlessAccount() {
         options.set(USERNAME, "user");
         new CifsWinrsConnection(CIFS_PROTOCOL, options, INSTANCE);
     }
 
+    @DataProvider
+    public Object[][] runOnlyOnWindows() {
+        return isWindowsOs() ? SINGLE_NO_ARG_INVOCATION : NO_INVOCATIONS;
+    }
 }

--- a/src/test/java/com/xebialabs/overthere/util/TestUtils.java
+++ b/src/test/java/com/xebialabs/overthere/util/TestUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2013, XebiaLabs B.V., All rights reserved.
+ *
+ *
+ * Overthere is licensed under the terms of the GPLv2
+ * <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most XebiaLabs Libraries.
+ * There are special exceptions to the terms and conditions of the GPLv2 as it is applied to
+ * this software, see the FLOSS License Exception
+ * <http://github.com/xebialabs/overthere/blob/master/LICENSE>.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation; version 2
+ * of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
+ * Floor, Boston, MA 02110-1301  USA
+ */
+package com.xebialabs.overthere.util;
+
+public class TestUtils {
+    public static final Object[][] NO_INVOCATIONS = new Object[0][0];
+    public static final Object[][] SINGLE_NO_ARG_INVOCATION = { new Object[0] };
+
+    public static boolean isWindowsOs() {
+        return System.getProperty("os.name", "").toLowerCase().contains("windows");
+    }
+}


### PR DESCRIPTION
Test succeeds locally:

```
.\gradlew test -Dtest.single=CifsWinRsConnectionTest
The Test.testResultsDir property has been deprecated and is scheduled to be removed in Gradle 2.0. Please use the Test.getReports().getJunitXml().setDestination() property instead.
The Test.testReportDir property has been deprecated and is scheduled to be removed in Gradle 2.0. Please use the Test.getReports().getHtml().getDestination() property instead.
:compileJava UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:compileTestJava UP-TO-DATE
:processTestResources UP-TO-DATE
:testClasses UP-TO-DATE
:test

BUILD SUCCESSFUL
```
