### PR TITLE
SshConnection can now bind to a specific local host address and/or local port 

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ Apart from selecting a protocol to use, you will also need to supply a number of
     <th align="left" valign="top"><a name="remoteCopyBufferSize"></a>remoteCopyBufferSize</th>
     <td>The buffer size to use when copying files from one connection to the other. The buffer size is taken from the _source_ file's connection. The default value is <code>64 KB (64*1024 bytes)</code>. Larger values potentially break copy operations.</td>
 </tr>
+<tr>
+    <th align="left" valign="top"><a name="bindAddress"></a>bindAddress</th>
+    <td>The address to use on the local machine as the source address of the connection. Only useful on systems with more than one address. The default value is '0.0.0.0', i.e. let the OS decide. N.B. implemented for SshConnections only. </td>
+</tr>
+<tr>
+    <th align="left" valign="top"><a name="bindPort"></a>bindPort</th>
+    <td>The port to use on the local machine as the source port of the connection. The default value is '0', i.e. let the OS pick a free port. N.B. implemented for SshConnections only. </td>
+</tr>
 
 </table>
 

--- a/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
+++ b/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
@@ -24,6 +24,7 @@ package com.xebialabs.overthere;
 
 import java.util.Map;
 import java.util.Set;
+
 import com.google.common.collect.ImmutableSet;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -83,6 +84,17 @@ public class ConnectionOptions {
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#port">the online documentation</a>
      */
     public static final String PORT = "port";
+
+    /**
+     * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#bindAddress">the online
+     * documentation</a>
+     */
+    public static final String BIND_ADDRESS = "bindAddress";
+
+    /**
+     * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#bindPort">the online documentation</a>
+     */
+    public static final String BIND_PORT = "bindPort";
 
     /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#username">the online documentation</a>

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
@@ -23,22 +23,11 @@
 package com.xebialabs.overthere.ssh;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.google.common.annotations.VisibleForTesting;
-
-import com.xebialabs.overthere.CmdLine;
-import com.xebialabs.overthere.CmdLineArgument;
-import com.xebialabs.overthere.ConnectionOptions;
-import com.xebialabs.overthere.OverthereFile;
-import com.xebialabs.overthere.OverthereProcess;
-import com.xebialabs.overthere.RuntimeIOException;
-import com.xebialabs.overthere.spi.AddressPortMapper;
-import com.xebialabs.overthere.spi.BaseOverthereConnection;
 
 import net.schmizz.sshj.Config;
 import net.schmizz.sshj.DefaultConfig;
@@ -56,10 +45,26 @@ import net.schmizz.sshj.userauth.method.AuthPassword;
 import net.schmizz.sshj.userauth.password.PasswordFinder;
 import net.schmizz.sshj.userauth.password.Resource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.xebialabs.overthere.CmdLine;
+import com.xebialabs.overthere.CmdLineArgument;
+import com.xebialabs.overthere.ConnectionOptions;
+import com.xebialabs.overthere.OverthereFile;
+import com.xebialabs.overthere.OverthereProcess;
+import com.xebialabs.overthere.RuntimeIOException;
+import com.xebialabs.overthere.spi.AddressPortMapper;
+import com.xebialabs.overthere.spi.BaseOverthereConnection;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.xebialabs.overthere.ConnectionOptions.ADDRESS;
+import static com.xebialabs.overthere.ConnectionOptions.BIND_ADDRESS;
+import static com.xebialabs.overthere.ConnectionOptions.BIND_PORT;
 import static com.xebialabs.overthere.ConnectionOptions.PASSWORD;
 import static com.xebialabs.overthere.ConnectionOptions.PORT;
 import static com.xebialabs.overthere.ConnectionOptions.USERNAME;
@@ -72,8 +77,8 @@ import static com.xebialabs.overthere.ssh.SshConnectionBuilder.INTERACTIVE_KEYBO
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.OPEN_SHELL_BEFORE_EXECUTE;
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.OPEN_SHELL_BEFORE_EXECUTE_DEFAULT;
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.PASSPHRASE;
-import static com.xebialabs.overthere.ssh.SshConnectionBuilder.PRIVATE_KEY_FILE;
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.PORT_DEFAULT_SSH;
+import static com.xebialabs.overthere.ssh.SshConnectionBuilder.PRIVATE_KEY_FILE;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
 import static com.xebialabs.overthere.util.OverthereUtils.constructPath;
 import static java.lang.String.format;
@@ -93,6 +98,10 @@ abstract class SshConnection extends BaseOverthereConnection {
     protected String host;
 
     protected int port;
+
+    protected String bindAddress;
+
+    protected int bindPort;
 
     protected String username;
 
@@ -132,6 +141,8 @@ abstract class SshConnection extends BaseOverthereConnection {
         InetSocketAddress addressPort = mapper.map(createUnresolved(unmappedAddress, unmappedPort));
         host = addressPort.getHostName();
         port = addressPort.getPort();
+        bindAddress = options.get(BIND_ADDRESS, "0.0.0.0");
+        bindPort = options.getInteger(BIND_PORT, 0);
         username = options.get(USERNAME);
         password = options.getOptional(PASSWORD);
         interactiveKeyboardAuthPromptRegex = options.get(INTERACTIVE_KEYBOARD_AUTH_PROMPT_REGEX, INTERACTIVE_KEYBOARD_AUTH_PROMPT_REGEX_DEFAULT);
@@ -152,7 +163,7 @@ abstract class SshConnection extends BaseOverthereConnection {
             client.addHostKeyVerifier(new PromiscuousVerifier());
 
             try {
-                client.connect(host, port);
+                client.connect(host, port, InetAddress.getByName(bindAddress), bindPort);
             } catch (IOException e) {
                 throw new RuntimeIOException("Cannot connect to " + host + ":" + port, e);
             }


### PR DESCRIPTION
Adds ability to  bind to a specific local host address and/or local port  to SshConnection via options 'bindAddress' and 'bindPort', like OpenSSHs' '-b' parameter.
Binding to a specific local address or port may be necessary for compliance with network policies (e.g. routing or firewall settings).
