### PR TITLE
Modified WinRM classes to work with IBM JDK

### DIFF
--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/JavaVendor.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/JavaVendor.java
@@ -25,12 +25,24 @@ package com.xebialabs.overthere.cifs.winrm;
 import java.util.HashMap;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
+import org.ietf.jgss.GSSContext;
 
 class JavaVendor {
 
-	private static final boolean IBM_JAVA =  System.getProperty("java.vendor").contains("IBM");
+    private static final boolean IBM_JAVA =  System.getProperty("java.vendor").toUpperCase().contains("IBM");
 
-	public static boolean isIBM() {
-		return IBM_JAVA;
-	}
+    public static boolean isIBM() {
+        return IBM_JAVA;
+    }
+
+    public static String getKrb5LoginModuleName() {
+        return isIBM() ? "com.ibm.security.auth.module.Krb5LoginModule"
+            : "com.sun.security.auth.module.Krb5LoginModule";
+    }
+
+    public static int getSpnegoLifetime() {
+        // With IBM JDK we need to use GSSContext.INDEFINITE_LIFETIME for SPNEGO
+        // ref http://www-01.ibm.com/support/docview.wss?uid=swg1IZ54545
+        return isIBM() ? GSSContext.INDEFINITE_LIFETIME : GSSContext.DEFAULT_LIFETIME;
+    }
 }

--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/KerberosJaasConfiguration.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/KerberosJaasConfiguration.java
@@ -38,26 +38,24 @@ class KerberosJaasConfiguration extends Configuration {
     public AppConfigurationEntry[] getAppConfigurationEntry(String s) {
         final HashMap<String, String> options = new HashMap<String, String>();
 
+        if (debug) {
+            options.put("debug", "true");
+        }
+        options.put("refreshKrb5Config", "true");
+        
         if (JavaVendor.isIBM()) {
-            options.put("refreshKrb5Config", "true");
+            options.put("credsType", "initiator");
         } else {
             options.put("client", "true");
             options.put("useTicketCache", "false");
             options.put("useKeyTab", "false");
             options.put("doNotPrompt", "false");
-            options.put("refreshKrb5Config", "true");
-            if (debug) {
-                options.put("debug", "true");
-            }
         }
 
-        return new AppConfigurationEntry[]{new AppConfigurationEntry(getKrb5LoginModuleName(),
+        return new AppConfigurationEntry[]{new AppConfigurationEntry(JavaVendor.getKrb5LoginModuleName(),
                 AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, options)};
     }
 
-    private String getKrb5LoginModuleName() {
-        return (JavaVendor.isIBM() ? "com.ibm.security.auth.module.Krb5LoginModule"
-            : "com.sun.security.auth.module.Krb5LoginModule");
-    }
+    
 
 }

--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/WsmanSPNegoScheme.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/WsmanSPNegoScheme.java
@@ -69,10 +69,7 @@ class WsmanSPNegoScheme extends SPNegoScheme {
         GSSName canonicalizedName = serverName.canonicalize(oid);
 
         logger.debug("Creating SPNego GSS context for canonicalized SPN {}", canonicalizedName);
-        // With IBM JDK we need to use GSSContext.INDEFINITE_LIFETIME for SPNEGO
-        // ref http://www-01.ibm.com/support/docview.wss?uid=swg1IZ54545
-        int spnegoLifetime = (JavaVendor.isIBM() ? GSSContext.INDEFINITE_LIFETIME : GSSContext.DEFAULT_LIFETIME);
-        GSSContext gssContext = manager.createContext(canonicalizedName, oid, null, spnegoLifetime);
+        GSSContext gssContext = manager.createContext(canonicalizedName, oid, null, JavaVendor.getSpnegoLifetime());
         gssContext.requestMutualAuth(true);
         gssContext.requestCredDeleg(true);
         return gssContext.initSecContext(token, 0, token.length);


### PR DESCRIPTION
We are using Overthere at work, and like it very much.  But recently we swithced to the IBM JDK, and the Kerberos support in the internal WinRm implementation in Overthere doesn't work with the IBM JDK.  I have done some modifications to make it work, and I hope these changes can be added to the next release of Overthere.
