### PR TITLE
Remove compile time dependency on Guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ configurations {
 
 dependencies {
   // General dependencies
-  compile 'com.google.guava:guava:16.0.1'
   compile 'nl.javadude.scannit:scannit:1.2.1'
   compile 'org.slf4j:slf4j-api:1.6.3'
   compile 'org.slf4j:jcl-over-slf4j:1.6.3'
@@ -88,6 +87,8 @@ dependencies {
   testCompile 'org.mockito:mockito-core:1.8.5'
   testCompile 'org.testng:testng:5.14.10'
   testCompile 'nl.javadude.assumeng:assumeng:1.2.2'
+  testCompile 'com.google.guava:guava:16.0.1'
+
 
   testRuntime 'ch.qos.logback:logback-classic:1.0.6'
   testRuntime('org.uncommons:reportng:1.1.2') {
@@ -113,8 +114,8 @@ task itest(type: Test) {
   }
 
   includes = ['**/*Itest.*', '**/LocalConnectionTest.*']
-  testResultsDir = file("${buildDir}/itest-results")
-  testReportDir = file("${buildDir}/reports/itests")
+  reports.junitXml.destination = file("${buildDir}/itest-results")
+  reports.html.destination = file("${buildDir}/reports/itests")
 
   maxHeapSize = "512m"
   copyProjectPropertyToSystemProperty(project, systemProperties, 'itests')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-bin.zip

--- a/src/main/java/com/xebialabs/overthere/CmdLine.java
+++ b/src/main/java/com/xebialabs/overthere/CmdLine.java
@@ -24,13 +24,11 @@ package com.xebialabs.overthere;
 
 import java.io.Serializable;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.List;
-import com.google.common.base.Function;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Lists.transform;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
+import static com.xebialabs.overthere.util.OverthereUtils.checkState;
 import static com.xebialabs.overthere.CmdLineArgument.arg;
 import static com.xebialabs.overthere.CmdLineArgument.nested;
 import static com.xebialabs.overthere.CmdLineArgument.password;
@@ -44,7 +42,7 @@ import static java.util.Collections.unmodifiableList;
 @SuppressWarnings("serial")
 public class CmdLine implements Serializable {
 
-    List<CmdLineArgument> arguments = newArrayList();
+    List<CmdLineArgument> arguments = new ArrayList<CmdLineArgument>();
 
     /**
      * Adds {@link CmdLineArgument#arg(String) a regular argument} to the command line.
@@ -154,12 +152,12 @@ public class CmdLine implements Serializable {
      */
     public String[] toCommandArray(final OperatingSystemFamily os, final boolean forLogging) {
         checkState(arguments.size() > 0, "Cannot encode empty command line");
-        return transform(arguments, new Function<CmdLineArgument, String>() {
-            @Override
-            public String apply(CmdLineArgument from) {
-                return from.toString(os, forLogging);
-            }
-        }).toArray(new String[arguments.size()]);
+        String[] args = new String[arguments.size()];
+        for (int i = 0; i < arguments.size(); i++) {
+            args[i] = arguments.get(i).toString(os, forLogging);
+
+        }
+        return args;
     }
 
     /**

--- a/src/main/java/com/xebialabs/overthere/CmdLineArgument.java
+++ b/src/main/java/com/xebialabs/overthere/CmdLineArgument.java
@@ -24,7 +24,7 @@ package com.xebialabs.overthere;
 
 import java.io.Serializable;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.OperatingSystemFamily.UNIX;
 
 /**

--- a/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
+++ b/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
@@ -22,12 +22,8 @@
  */
 package com.xebialabs.overthere;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
-import com.google.common.collect.ImmutableSet;
-
-import static com.google.common.collect.Maps.newHashMap;
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.PASSPHRASE;
 
 /**
@@ -172,20 +168,28 @@ public class ConnectionOptions {
 
     private final Map<String, Object> options;
 
-    private static final ImmutableSet<String> filteredKeys = ImmutableSet.of(PASSWORD, PASSPHRASE);
+    private static final Set<String> filteredKeys = getFilteredKeys();
+
+    private static Set<String> getFilteredKeys() {
+        HashSet<String> strings = new HashSet<String>();
+        strings.add(PASSWORD);
+        strings.add(PASSPHRASE);
+        return Collections.unmodifiableSet(strings);
+    }
 
     /**
      * Creates an empty options object.
      */
     public ConnectionOptions() {
-        options = newHashMap();
+        options = new HashMap<String, Object>();
     }
 
     /**
      * Creates a copy of an existing options object.
      */
     public ConnectionOptions(ConnectionOptions options) {
-        this.options = newHashMap(options.options);
+        this();
+        this.options.putAll(options.options);
     }
 
     /**

--- a/src/main/java/com/xebialabs/overthere/cifs/CifsConnectionBuilder.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/CifsConnectionBuilder.java
@@ -22,8 +22,8 @@
  */
 package com.xebialabs.overthere.cifs;
 
+import java.util.Collections;
 import java.util.Map;
-import com.google.common.collect.ImmutableMap;
 
 import com.xebialabs.overthere.ConnectionOptions;
 import com.xebialabs.overthere.OverthereConnection;
@@ -88,7 +88,7 @@ public class CifsConnectionBuilder implements OverthereConnectionBuilder {
     /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#cifs_pathShareMappings">the online documentation</a>
      */
-    public static final Map<String, String> PATH_SHARE_MAPPINGS_DEFAULT = ImmutableMap.of();
+    public static final Map<String, String> PATH_SHARE_MAPPINGS_DEFAULT = Collections.emptyMap();
 
     /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#cifs_winrmEnableHttps">the online documentation</a>

--- a/src/main/java/com/xebialabs/overthere/cifs/CifsFile.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/CifsFile.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +38,6 @@ import com.xebialabs.overthere.spi.BaseOverthereFile;
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 
 class CifsFile extends BaseOverthereFile<CifsConnection> {
@@ -177,7 +177,7 @@ class CifsFile extends BaseOverthereFile<CifsConnection> {
 
         try {
             upgradeToDirectorySmbFile();
-            List<OverthereFile> files = newArrayList();
+            List<OverthereFile> files = new ArrayList<OverthereFile>();
             for (String name : smbFile.list()) {
                 files.add(getFile(name));
             }

--- a/src/main/java/com/xebialabs/overthere/cifs/telnet/CifsTelnetConnection.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/telnet/CifsTelnetConnection.java
@@ -43,8 +43,8 @@ import com.xebialabs.overthere.RuntimeIOException;
 import com.xebialabs.overthere.cifs.CifsConnection;
 import com.xebialabs.overthere.spi.AddressPortMapper;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.CIFS_PROTOCOL;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;

--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
@@ -42,8 +42,8 @@ import com.xebialabs.overthere.cifs.WinrmHttpsCertificateTrustStrategy;
 import com.xebialabs.overthere.cifs.WinrmHttpsHostnameVerificationStrategy;
 import com.xebialabs.overthere.spi.AddressPortMapper;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.CIFS_PROTOCOL;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_CONTEXT_DEFAULT;

--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/soap/OptionSet.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/soap/OptionSet.java
@@ -22,20 +22,23 @@
  */
 package com.xebialabs.overthere.cifs.winrm.soap;
 
+import java.util.ArrayList;
 import java.util.List;
-import com.google.common.collect.Lists;
 
 /**
  */
 public enum OptionSet {
 
-    OPEN_SHELL(Lists.newArrayList(new KeyValuePair("WINRS_NOPROFILE", "FALSE"), new KeyValuePair("WINRS_CODEPAGE", "437"))),
-    RUN_COMMAND(Lists.newArrayList(new KeyValuePair("WINRS_CONSOLEMODE_STDIN", "TRUE")));
+    OPEN_SHELL(new KeyValuePair("WINRS_NOPROFILE", "FALSE"), new KeyValuePair("WINRS_CODEPAGE", "437")),
+    RUN_COMMAND(new KeyValuePair("WINRS_CONSOLEMODE_STDIN", "TRUE"));
 
     private final List<KeyValuePair> keyValuePairs;
 
-    OptionSet(List<KeyValuePair> keyValuePairs) {
-        this.keyValuePairs = keyValuePairs;
+    OptionSet(KeyValuePair... keyValuePairs) {
+        this.keyValuePairs = new ArrayList<KeyValuePair>();
+        for (KeyValuePair keyValuePair : keyValuePairs) {
+            this.keyValuePairs.add(keyValuePair);
+        }
     }
 
     public List<KeyValuePair> getKeyValuePairs() {

--- a/src/main/java/com/xebialabs/overthere/cifs/winrs/CifsWinrsConnection.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrs/CifsWinrsConnection.java
@@ -34,8 +34,8 @@ import com.xebialabs.overthere.cifs.CifsConnection;
 import com.xebialabs.overthere.spi.AddressPortMapper;
 import com.xebialabs.overthere.util.DefaultAddressPortMapper;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.CIFS_PROTOCOL;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_ENABLE_HTTPS_DEFAULT;

--- a/src/main/java/com/xebialabs/overthere/local/LocalConnection.java
+++ b/src/main/java/com/xebialabs/overthere/local/LocalConnection.java
@@ -40,8 +40,8 @@ import com.xebialabs.overthere.spi.OverthereConnectionBuilder;
 import com.xebialabs.overthere.spi.Protocol;
 import com.xebialabs.overthere.util.DefaultAddressPortMapper;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.ConnectionOptions.OPERATING_SYSTEM;
 import static com.xebialabs.overthere.ConnectionOptions.TEMPORARY_DIRECTORY_PATH;
 import static com.xebialabs.overthere.OperatingSystemFamily.getLocalHostOperatingSystemFamily;

--- a/src/main/java/com/xebialabs/overthere/local/LocalFile.java
+++ b/src/main/java/com/xebialabs/overthere/local/LocalFile.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.xebialabs.overthere.ConnectionOptions;
@@ -36,7 +37,6 @@ import com.xebialabs.overthere.OverthereFile;
 import com.xebialabs.overthere.RuntimeIOException;
 import com.xebialabs.overthere.spi.BaseOverthereFile;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static com.xebialabs.overthere.local.LocalConnection.LOCAL_PROTOCOL;
 
 /**
@@ -162,7 +162,7 @@ public class LocalFile extends BaseOverthereFile<LocalConnection> implements Ser
 
     @Override
     public List<OverthereFile> listFiles() {
-        List<OverthereFile> list = newArrayList();
+        List<OverthereFile> list = new ArrayList<OverthereFile>();
         for (File each : file.listFiles()) {
             list.add(new LocalFile(connection, each));
         }

--- a/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
+++ b/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
@@ -25,6 +25,7 @@ package com.xebialabs.overthere.spi;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
@@ -42,9 +43,7 @@ import com.xebialabs.overthere.OverthereProcess;
 import com.xebialabs.overthere.OverthereProcessOutputHandler;
 import com.xebialabs.overthere.RuntimeIOException;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.Lists.newArrayList;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.ConnectionOptions.*;
 import static com.xebialabs.overthere.util.ConsoleOverthereExecutionOutputHandler.syserrHandler;
 import static com.xebialabs.overthere.util.ConsoleOverthereExecutionOutputHandler.sysoutHandler;
@@ -72,7 +71,7 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
     protected final boolean deleteTemporaryDirectoryOnDisconnect;
     protected final int temporaryFileCreationRetries;
     protected final String temporaryFileHolderDirectoryNamePrefix;
-    protected final List<OverthereFile> temporaryFileHolderDirectories = newArrayList();
+    protected final List<OverthereFile> temporaryFileHolderDirectories = new ArrayList<OverthereFile>();
     protected final int streamBufferSize;
     protected int temporaryFileHolderDirectoryNameSuffix = 0;
     protected OverthereFile workingDirectory;
@@ -167,7 +166,7 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
      */
     @Override
     public final synchronized OverthereFile getTempFile(String name) {
-        if (isNullOrEmpty(name)) {
+        if (name == null || name.trim().isEmpty()) {
             name = "tmp";
         }
 

--- a/src/main/java/com/xebialabs/overthere/spi/BaseOverthereFile.java
+++ b/src/main/java/com/xebialabs/overthere/spi/BaseOverthereFile.java
@@ -35,7 +35,7 @@ import com.xebialabs.overthere.RuntimeIOException;
 import com.xebialabs.overthere.util.CapturingOverthereExecutionOutputHandler;
 import com.xebialabs.overthere.util.OverthereFileCopier;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
 import static com.xebialabs.overthere.ConnectionOptions.DIRECTORY_COPY_COMMAND_FOR_UNIX;
 import static com.xebialabs.overthere.ConnectionOptions.DIRECTORY_COPY_COMMAND_FOR_UNIX_DEFAULT;
 import static com.xebialabs.overthere.ConnectionOptions.DIRECTORY_COPY_COMMAND_FOR_WINDOWS;

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
@@ -48,8 +48,6 @@ import net.schmizz.sshj.userauth.password.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import com.xebialabs.overthere.CmdLine;
 import com.xebialabs.overthere.CmdLineArgument;
 import com.xebialabs.overthere.ConnectionOptions;
@@ -59,9 +57,9 @@ import com.xebialabs.overthere.RuntimeIOException;
 import com.xebialabs.overthere.spi.AddressPortMapper;
 import com.xebialabs.overthere.spi.BaseOverthereConnection;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
+import static com.xebialabs.overthere.util.OverthereUtils.checkState;
 import static com.xebialabs.overthere.ConnectionOptions.ADDRESS;
 import static com.xebialabs.overthere.ConnectionOptions.PASSWORD;
 import static com.xebialabs.overthere.ConnectionOptions.PORT;
@@ -125,7 +123,6 @@ abstract class SshConnection extends BaseOverthereConnection {
 
     private static final Config config = new DefaultConfig();
 
-    @VisibleForTesting
     protected Factory<SSHClient> sshClientFactory = new Factory<SSHClient>() {
         @Override
         public SSHClient create() {

--- a/src/main/java/com/xebialabs/overthere/ssh/SshElevatedUserConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshElevatedUserConnection.java
@@ -25,7 +25,6 @@ package com.xebialabs.overthere.ssh;
 import java.io.InputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.annotations.VisibleForTesting;
 
 import com.xebialabs.overthere.CmdLine;
 import com.xebialabs.overthere.CmdLineArgument;
@@ -38,7 +37,7 @@ import net.schmizz.sshj.connection.ConnectionException;
 import net.schmizz.sshj.connection.channel.direct.Session;
 import net.schmizz.sshj.transport.TransportException;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
 import static com.xebialabs.overthere.util.OverthereUtils.constructPath;
 
 /**
@@ -119,7 +118,6 @@ abstract class SshElevatedUserConnection extends SshScpConnection {
         return processedCmd;
     }
 
-    @VisibleForTesting
     CmdLine prefixWithElevationCommand(final CmdLine commandLine) {
         CmdLine commandLineWithSudo = new CmdLine();
         if (quoteCommand) {

--- a/src/main/java/com/xebialabs/overthere/ssh/SshFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshFile.java
@@ -22,20 +22,15 @@
  */
 package com.xebialabs.overthere.ssh;
 
-import java.util.List;
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-
-import com.xebialabs.overthere.CmdLine;
-import com.xebialabs.overthere.OperatingSystemFamily;
-import com.xebialabs.overthere.OverthereExecutionOutputHandler;
-import com.xebialabs.overthere.OverthereFile;
-import com.xebialabs.overthere.RuntimeIOException;
+import com.xebialabs.overthere.*;
 import com.xebialabs.overthere.spi.BaseOverthereFile;
 
-import static com.google.common.collect.Lists.newArrayList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
+import static com.xebialabs.overthere.util.OverthereUtils.mkString;
 
 /**
  * A file on a host connected through SSH.
@@ -138,8 +133,13 @@ abstract class SshFile<C extends SshConnection> extends BaseOverthereFile<C> {
     }
 
     static List<String> splitPath(String path, OperatingSystemFamily os) {
-        Splitter s = os == WINDOWS ? WINDOWS_PATH_SPLITTER : UNIX_PATH_SPLITTER;
-        return newArrayList(s.split(path));
+        Pattern s = os == WINDOWS ? WINDOWS_PATH_SPLITTER : UNIX_PATH_SPLITTER;
+        List<String> l = new ArrayList<String>();
+        for (String p : s.split(path)) {
+            if (p.isEmpty()) continue;
+            l.add(p);
+        }
+        return l;
     }
 
     static String joinPath(List<String> pathComponents, OperatingSystemFamily os) {
@@ -150,13 +150,13 @@ abstract class SshFile<C extends SshConnection> extends BaseOverthereFile<C> {
         }
 
         if (os == WINDOWS) {
-            String path = Joiner.on(fileSep).join(pathComponents);
+            String path = mkString(pathComponents, fileSep);
             if (pathComponents.size() == 1) {
                 path += fileSep;
             }
             return path;
         } else {
-            return fileSep + Joiner.on(fileSep).join(pathComponents);
+            return fileSep + mkString(pathComponents, fileSep);
         }
     }
 
@@ -166,8 +166,8 @@ abstract class SshFile<C extends SshConnection> extends BaseOverthereFile<C> {
         }
     }
 
-    private static final Splitter UNIX_PATH_SPLITTER = Splitter.on('/').omitEmptyStrings();
+    private static final Pattern UNIX_PATH_SPLITTER = Pattern.compile("/");
 
-    private static final Splitter WINDOWS_PATH_SPLITTER = Splitter.on(CharMatcher.anyOf("/\\")).omitEmptyStrings();
+    private static final Pattern WINDOWS_PATH_SPLITTER = Pattern.compile("[/\\\\]");
 
 }

--- a/src/main/java/com/xebialabs/overthere/ssh/SshProcess.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshProcess.java
@@ -38,7 +38,7 @@ import net.schmizz.sshj.connection.channel.direct.Session;
 import net.schmizz.sshj.connection.channel.direct.Signal;
 import net.schmizz.sshj.transport.TransportException;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
 import static java.lang.String.format;
 
 class SshProcess implements OverthereProcess {

--- a/src/main/java/com/xebialabs/overthere/ssh/SshScpConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshScpConnection.java
@@ -27,7 +27,7 @@ import com.xebialabs.overthere.OverthereFile;
 import com.xebialabs.overthere.RuntimeIOException;
 import com.xebialabs.overthere.spi.AddressPortMapper;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
 import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
 import static com.xebialabs.overthere.OperatingSystemFamily.ZOS;
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.DELETE_DIRECTORY_COMMAND;

--- a/src/main/java/com/xebialabs/overthere/ssh/SshScpFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshScpFile.java
@@ -28,13 +28,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 
 import com.xebialabs.overthere.CmdLine;
 import com.xebialabs.overthere.OverthereFile;
@@ -45,8 +44,6 @@ import net.schmizz.sshj.xfer.LocalFileFilter;
 import net.schmizz.sshj.xfer.LocalSourceFile;
 import net.schmizz.sshj.xfer.scp.SCPUploadClient;
 
-import static com.google.common.base.Predicates.equalTo;
-import static com.google.common.collect.Lists.newArrayList;
 import static com.xebialabs.overthere.CmdLine.build;
 import static com.xebialabs.overthere.ssh.SshConnection.NOCD_PSEUDO_COMMAND;
 import static com.xebialabs.overthere.util.CapturingOverthereExecutionOutputHandler.capturingHandler;
@@ -60,8 +57,6 @@ import static java.lang.String.format;
  * A file on a host connected through SSH w/ SCP.
  */
 class SshScpFile extends SshFile<SshScpConnection> {
-
-    private static final Predicate<String> NOT_SELF_OR_PARENT_DIR = Predicates.<String>not(Predicates.<String>or(equalTo("."), equalTo("..")));
 
     private static final String PERMISSIONS_TOKEN_PATTERN = "[dl\\-]([r\\-][w\\-][xsStT\\-]){3}[@\\.\\+]*";
 
@@ -274,10 +269,10 @@ class SshScpFile extends SshFile<SshScpConnection> {
             throw new RuntimeIOException("Cannot list directory " + this + ": " + capturedStderr.getOutput() + " (errno=" + errno + ")");
         }
 
-        List<OverthereFile> files = newArrayList();
+        List<OverthereFile> files = new ArrayList<OverthereFile>();
         for (String lsLine : capturedStdout.getOutputLines()) {
             // Filter out the '.' and '..'
-            if (NOT_SELF_OR_PARENT_DIR.apply(lsLine)) {
+            if (!(".".equals(lsLine) || "..".equals(lsLine))) {
                 files.add(connection.getFile(this, lsLine));
             }
         }
@@ -428,7 +423,7 @@ class SshScpFile extends SshFile<SshScpConnection> {
 
         @Override
         public Iterable<? extends LocalSourceFile> getChildren(LocalFileFilter filter) throws IOException {
-            List<LocalSourceFile> files = newArrayList();
+            List<LocalSourceFile> files = new ArrayList<LocalSourceFile>();
             for (OverthereFile each : f.listFiles()) {
                 files.add(new OverthereFileLocalSourceFile(each));
             }

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpConnection.java
@@ -33,7 +33,7 @@ import com.xebialabs.overthere.spi.AddressPortMapper;
 
 import net.schmizz.sshj.sftp.SFTPClient;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.xebialabs.overthere.util.OverthereUtils.checkState;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
 import static java.lang.String.format;
 

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpCygwinConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpCygwinConnection.java
@@ -36,7 +36,7 @@ import net.schmizz.sshj.connection.ConnectionException;
 import net.schmizz.sshj.connection.channel.direct.Session;
 import net.schmizz.sshj.transport.TransportException;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
 import static com.xebialabs.overthere.ConnectionOptions.FILE_COPY_COMMAND_FOR_WINDOWS;
 import static com.xebialabs.overthere.ConnectionOptions.FILE_COPY_COMMAND_FOR_WINDOWS_DEFAULT;
 import static com.xebialabs.overthere.OperatingSystemFamily.UNIX;

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpFile.java
@@ -22,26 +22,20 @@
  */
 package com.xebialabs.overthere.ssh;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
+import com.xebialabs.overthere.OverthereFile;
+import com.xebialabs.overthere.RuntimeIOException;
+import net.schmizz.sshj.sftp.*;
+import net.schmizz.sshj.xfer.FilePermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.xebialabs.overthere.OverthereFile;
-import com.xebialabs.overthere.RuntimeIOException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
 
-import net.schmizz.sshj.sftp.FileAttributes;
-import net.schmizz.sshj.sftp.FileMode;
-import net.schmizz.sshj.sftp.OpenMode;
-import net.schmizz.sshj.sftp.RemoteFile;
-import net.schmizz.sshj.sftp.RemoteResourceInfo;
-import net.schmizz.sshj.sftp.SFTPClient;
-import net.schmizz.sshj.xfer.FilePermission;
-
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
 import static java.lang.String.format;
 
@@ -127,7 +121,7 @@ class SshSftpFile extends SshFile<SshSftpConnection> {
             List<RemoteResourceInfo> ls = connection.getSharedSftpClient().ls(getSftpPath());
 
             // copy files to list, skipping . and ..
-            List<OverthereFile> files = newArrayList();
+            List<OverthereFile> files = new ArrayList<OverthereFile>();
             for (RemoteResourceInfo l : ls) {
                 String filename = l.getName();
                 if (filename.equals(".") || filename.equals("..")) {
@@ -231,7 +225,7 @@ class SshSftpFile extends SshFile<SshSftpConnection> {
 
         try {
             final SFTPClient sftp = connection.connectSftp();
-            final RemoteFile remoteFile = sftp.open(getSftpPath(), newHashSet(OpenMode.READ));
+            final RemoteFile remoteFile = sftp.open(getSftpPath(), EnumSet.of(OpenMode.READ));
             final InputStream wrapped = remoteFile.new RemoteFileInputStream();
 
             return asBuffered(new InputStream() {
@@ -298,7 +292,7 @@ class SshSftpFile extends SshFile<SshSftpConnection> {
 
         try {
             final SFTPClient sftp = connection.connectSftp();
-            final RemoteFile remoteFile = sftp.open(getSftpPath(), newHashSet(OpenMode.CREAT, OpenMode.WRITE, OpenMode.TRUNC));
+            final RemoteFile remoteFile = sftp.open(getSftpPath(), EnumSet.of(OpenMode.CREAT, OpenMode.WRITE, OpenMode.TRUNC));
             final OutputStream wrapped = remoteFile.new RemoteFileOutputStream();
 
             return asBuffered(new OutputStream() {

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpUnixConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpUnixConnection.java
@@ -25,7 +25,7 @@ package com.xebialabs.overthere.ssh;
 import com.xebialabs.overthere.ConnectionOptions;
 import com.xebialabs.overthere.spi.AddressPortMapper;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
 import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.SSH_PROTOCOL;
 

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpWinSshdConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpWinSshdConnection.java
@@ -29,7 +29,7 @@ import com.xebialabs.overthere.ConnectionOptions;
 import com.xebialabs.overthere.RuntimeIOException;
 import com.xebialabs.overthere.spi.AddressPortMapper;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
 import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.SSH_PROTOCOL;
 import static java.lang.Character.toUpperCase;

--- a/src/main/java/com/xebialabs/overthere/util/ByteArrayFile.java
+++ b/src/main/java/com/xebialabs/overthere/util/ByteArrayFile.java
@@ -25,6 +25,7 @@ package com.xebialabs.overthere.util;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.xebialabs.overthere.ConnectionOptions;
@@ -32,7 +33,6 @@ import com.xebialabs.overthere.OperatingSystemFamily;
 import com.xebialabs.overthere.OverthereFile;
 import com.xebialabs.overthere.spi.BaseOverthereFile;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static com.xebialabs.overthere.ConnectionOptions.OPERATING_SYSTEM;
 import static com.xebialabs.overthere.ConnectionOptions.TEMPORARY_DIRECTORY_PATH;
 import static com.xebialabs.overthere.OperatingSystemFamily.getLocalHostOperatingSystemFamily;
@@ -152,7 +152,7 @@ public class ByteArrayFile extends BaseOverthereFile<ByteArrayConnection> {
 
     @Override
     public List<OverthereFile> listFiles() {
-        return newArrayList();
+        return new ArrayList<OverthereFile>();
     }
 
     @Override

--- a/src/main/java/com/xebialabs/overthere/util/CapturingOverthereExecutionOutputHandler.java
+++ b/src/main/java/com/xebialabs/overthere/util/CapturingOverthereExecutionOutputHandler.java
@@ -22,13 +22,13 @@
  */
 package com.xebialabs.overthere.util;
 
-import java.util.Collections;
-import java.util.List;
-import com.google.common.collect.Lists;
-
 import com.xebialabs.overthere.OverthereExecutionOutputHandler;
 
-import static com.google.common.base.Joiner.on;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.xebialabs.overthere.util.OverthereUtils.mkString;
 import static java.util.Collections.unmodifiableList;
 
 /**
@@ -36,7 +36,7 @@ import static java.util.Collections.unmodifiableList;
  */
 public class CapturingOverthereExecutionOutputHandler implements OverthereExecutionOutputHandler {
 
-    private List<String> outputLines = Collections.synchronizedList(Lists.<String>newArrayList());
+    private List<String> outputLines = Collections.synchronizedList(new ArrayList<String>());
 
     private CapturingOverthereExecutionOutputHandler() {
     }
@@ -66,7 +66,7 @@ public class CapturingOverthereExecutionOutputHandler implements OverthereExecut
      * @return the captured regular output as one string.
      */
     public String getOutput() {
-        return on('\n').join(outputLines);
+        return mkString(outputLines, '\n');
     }
 
     /**

--- a/src/main/java/com/xebialabs/overthere/util/CapturingOverthereProcessOutputHandler.java
+++ b/src/main/java/com/xebialabs/overthere/util/CapturingOverthereProcessOutputHandler.java
@@ -22,12 +22,12 @@
  */
 package com.xebialabs.overthere.util;
 
+import com.xebialabs.overthere.OverthereProcessOutputHandler;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import com.xebialabs.overthere.OverthereProcessOutputHandler;
-
-import static com.google.common.base.Joiner.on;
+import static com.xebialabs.overthere.util.OverthereUtils.mkString;
 import static java.util.Collections.unmodifiableList;
 
 /**
@@ -79,7 +79,7 @@ public final class CapturingOverthereProcessOutputHandler implements OvertherePr
      * @return the captured regular output as one string.
      */
     public String getOutput() {
-        return on('\n').join(outputLines);
+        return mkString(outputLines, '\n');
     }
 
     /**
@@ -97,7 +97,7 @@ public final class CapturingOverthereProcessOutputHandler implements OvertherePr
      * @return the captured error output as one string.
      */
     public String getError() {
-        return on('\n').join(errorLines);
+        return mkString(errorLines, '\n');
     }
 
     /**
@@ -115,7 +115,7 @@ public final class CapturingOverthereProcessOutputHandler implements OvertherePr
      * @return the captured regular and error output as one string.
      */
     public String getAll() {
-        return on('\n').join(allLines);
+        return mkString(allLines, '\n');
     }
 
     /**
@@ -128,5 +128,7 @@ public final class CapturingOverthereProcessOutputHandler implements OvertherePr
     public static CapturingOverthereProcessOutputHandler capturingHandler() {
         return new CapturingOverthereProcessOutputHandler();
     }
+
+
 
 }

--- a/src/test/java/com/xebialabs/overthere/UnixCloudHostListener.java
+++ b/src/test/java/com/xebialabs/overthere/UnixCloudHostListener.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.xebialabs.overcast.host.CloudHost;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 
 public class UnixCloudHostListener extends CloudHostListener {
 

--- a/src/test/java/com/xebialabs/overthere/WindowsCloudHostListener.java
+++ b/src/test/java/com/xebialabs/overthere/WindowsCloudHostListener.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.xebialabs.overcast.host.CloudHost;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 
 public class WindowsCloudHostListener extends CloudHostListener {
 


### PR DESCRIPTION
Guava is a bad dependency for a library as different versions are sometimes incompatible due to methods being removed. Forcing a higher version of Guava through a library than your program has, might break in undetermined ways.
