### PR TITLE
Fix directory copy command for unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Apart from selecting a protocol to use, you will also need to supply a number of
 <tr>
     <th align="left" valign="top"><a name="directoryCopyCommandForUnix"></a>directoryCopyCommandForUnix</th>
     <td>The command to use when copying a directory on a Unix host. The string <code>{0}</code> is replaced with the path of the source directory, the string
-        <code>{1}</code> is replaced with the path of the destination directory. The default value is <code>cd {1} ; tar -cf - -C {0} . | tar xpf -</code>. If the
+        <code>{1}</code> is replaced with the path of the destination directory. The default value is <code>tar -cf - -C {0} . | tar xpf - -C {1}</code>. If the
         <code>tar</code> command is not available but the <code>find</code> command recognizes the <code>-depth</code> parameter with a value, the alternative
         command <code>find {0} -depth 1 -exec cp -pr {} {1} ;</code> may be configured.</td>
 </tr>

--- a/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
+++ b/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
@@ -114,7 +114,7 @@ public class ConnectionOptions {
     /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#directoryCopyCommandForUnix">the online documentation</a>
      */
-    public static final String DIRECTORY_COPY_COMMAND_FOR_UNIX_DEFAULT = "cd {1} ; tar -cf - -C {0} . | tar xpf -";
+    public static final String DIRECTORY_COPY_COMMAND_FOR_UNIX_DEFAULT = "tar -cf - -C {0} . | tar xpf - -C {1}";
 
     /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#fileCopyCommandForWindows">the online documentation</a>


### PR DESCRIPTION
 DIRECTORY_COPY_COMMAND_FOR_UNIX_DEFAULT did not check for the result of the 'cd' command. If it failed, the directory would be copied to the orginal working directory instead.
