### PR TITLE
SSH KeyFile supplying as String

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,10 @@ The SSH protocol implementation of Overthere defines a number of additional conn
 	<strong>N.B.:</strong> This connection option is only applicable for the <strong>SUDO</strong> and <strong>INTERACTIVE_SUDO</strong> connection types.</td>
 </tr>
 <tr>
+	<th align="left" valign="top"><a name="ssh_privateKey"></a>privateKey</th>
+	<td>The RSA private key as String to use when connecting to the remote host. When this connection option is specified, the <strong>password</strong> and <strong>privateKeyFile</strong> connection options are ignored.</td>
+</tr>
+<tr>
 	<th align="left" valign="top"><a name="ssh_privateKeyFile"></a>privateKeyFile</th>
 	<td>The RSA private key file to use when connecting to the remote host. When this connection option is specified, the <strong>password</strong> connection option is ignored.</td>
 </tr>

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
@@ -152,7 +152,8 @@ abstract class SshConnection extends BaseOverthereConnection {
 
             if (!onlyOneNotNull(privateKey, privateKeyFile, password))
             {
-                logger.warn("You should only set one connection options between: privateKey, privateKeyFile, password. They are evaluated in this order, and latter would have no effect on the connection.");
+                String[] vars = { PRIVATE_KEY, PRIVATE_KEY_FILE, PASSWORD };
+                logger.warn("You should only set one connection options between: {}, {}, {}. They are evaluated in this order, and latter would have no effect on the connection.", vars);
             }
 
             KeyProvider keys;

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnectionBuilder.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnectionBuilder.java
@@ -176,6 +176,11 @@ public class SshConnectionBuilder implements OverthereConnectionBuilder {
     /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#ssh_passphrase">the online documentation</a>
      */
+    public static final String PRIVATE_KEY = "privateKey";
+
+    /**
+     * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#ssh_passphrase">the online documentation</a>
+     */
     public static final String PRIVATE_KEY_FILE = "privateKeyFile";
 
     /**


### PR DESCRIPTION
Hi,

I've added support to pass the SSH private key directly as String (and not only via external File as before).

I found SshTestUtils.createPrivateKeyFile used in tests, you can probably remove that too and directly use the new function in the integration tests.

p.s.: any ETA for a new release? (last one was on 27 Oct)

Thanks!