### PR TITLE
Prevent potential deadlock with WinRM

### DIFF
--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
@@ -224,6 +224,10 @@ public class CifsWinRmConnection extends CifsConnection {
                 @Override
                 public synchronized int exitValue() {
                     if (!processTerminated) {
+                        if(!outputReaderThread.isAlive()){
+                            processTerminated = true;
+                            return winRmClient.exitValue();
+                        }
                         throw new IllegalThreadStateException(format("Process for command [%s] on [%s] is still running", obfuscatedCmd,
                                 CifsWinRmConnection.this));
                     }


### PR DESCRIPTION
The processTerminated flag can now be set without explicitly calling waitFor() by polling the exitValue.  

The stdout and stderr InputStreams have relatively small buffers, and if they fill  up then waitFor() will hang until they are emptied.  This leads to needing two threads for emptying these buffers, and another thread to waitFor the exitValue.  In certain cases I've had the waitFor thread get locked out, and the slurping threads get caught in an infinite polling loop.

By having the exitValue check the outputReaderThread this seemed to eliminate the error.  Checking if a thread is alive when looking for an exitValue shouldn't cause a significant performance hit.