### PR TITLE
Added support for connection and socket timeout in WinRm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ Apart from selecting a protocol to use, you will also need to supply a number of
 	    2 minutes.</td>
 </tr>
 <tr>
+	<th align="left" valign="top"><a name="soTimeoutMillis"></a>soTimeoutMillis</th>
+	<td>The number of milliseconds Overthere will waits when no data is received on an open connection before raising exception. The default value is <code>0</code>, i.e.
+	    2 minutes.</td>
+</tr>
+<tr>
 	<th align="left" valign="top"><a name="jumpstation"></a>jumpstation</th>
 	<td>If set to a non-null value, this property contains the connection options used to connect to an SSH jumpstation (See
 	    <a href="#tunnelling">Tunnelling</a>). Recursive configuration is possible, i.e. this property is also available for the connection options of a

--- a/README.md
+++ b/README.md
@@ -147,11 +147,6 @@ Apart from selecting a protocol to use, you will also need to supply a number of
 	    2 minutes.</td>
 </tr>
 <tr>
-	<th align="left" valign="top"><a name="soTimeoutMillis"></a>soTimeoutMillis</th>
-	<td>The number of milliseconds Overthere will waits when no data is received on an open connection before raising exception. The default value is <code>0</code>, i.e.
-	    2 minutes.</td>
-</tr>
-<tr>
 	<th align="left" valign="top"><a name="jumpstation"></a>jumpstation</th>
 	<td>If set to a non-null value, this property contains the connection options used to connect to an SSH jumpstation (See
 	    <a href="#tunnelling">Tunnelling</a>). Recursive configuration is possible, i.e. this property is also available for the connection options of a
@@ -992,6 +987,10 @@ The CIFS protocol implementation of Overthere defines a number of additional con
 	<td>The WinRM timeout to use in <a href="http://www.w3.org/TR/xmlschema-2/#isoformats">XML schema duration format</a>. The default value is <code>PT60.000S</code>.
 	<br/>
 	<strong>N.B.:</strong> This connection option is only applicable for the <strong>WINRM_INTERNAL</strong> connection type.</td>
+</tr>
+<tr>
+	<th align="left" valign="top"><a name="winrmSoTimeoutMillis"></a>winrmSoTimeoutMillis</th>
+	<td>The number of milliseconds Overthere will waits when no data is received on an open connection before raising exception. The default value is <code>0</code>, meaning that read operations will not time out (infinite timeout).</td>
 </tr>
 <tr>
 	<th align="left" valign="top"><a name="cifs_winrsAllowDelegate"></a>winrsAllowDelegate</th>

--- a/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
+++ b/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
@@ -73,16 +73,6 @@ public class ConnectionOptions {
     public static final int CONNECTION_TIMEOUT_MILLIS_DEFAULT = 120000;
 
     /**
-     * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#soTimeoutMillis">the online documentation</a>
-     */
-    public static final String SO_TIMEOUT_MILLIS = "soTimeoutMillis";
-
-    /**
-     * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#soTimeoutMillis">the online documentation</a>
-     */
-    public static final int SO_TIMEOUT_MILLIS_DEFAULT = 0;
-
-    /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#address">the online documentation</a>
      */
     public static final String ADDRESS = "address";

--- a/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
+++ b/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
@@ -73,6 +73,16 @@ public class ConnectionOptions {
     public static final int CONNECTION_TIMEOUT_MILLIS_DEFAULT = 120000;
 
     /**
+     * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#soTimeoutMillis">the online documentation</a>
+     */
+    public static final String SO_TIMEOUT_MILLIS = "soTimeoutMillis";
+
+    /**
+     * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#soTimeoutMillis">the online documentation</a>
+     */
+    public static final int SO_TIMEOUT_MILLIS_DEFAULT = 0;
+
+    /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#address">the online documentation</a>
      */
     public static final String ADDRESS = "address";

--- a/src/main/java/com/xebialabs/overthere/cifs/CifsConnectionBuilder.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/CifsConnectionBuilder.java
@@ -200,6 +200,16 @@ public class CifsConnectionBuilder implements OverthereConnectionBuilder {
      */
     public static final String DEFAULT_WINRM_TIMEOUT = "PT60.000S";
 
+	/**
+	 * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#winrmSoTimeoutMillis">the online documentation</a>
+	 */
+	public static final String WINRM_SO_TIMEOUT_MILLIS = "winrmSoTimeoutMillis";
+
+	/**
+	 * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#soTimeoutMillis">the online documentation</a>
+	 */
+	public static final int WINRM_SO_TIMEOUT_MILLIS_DEFAULT = 0;
+
     /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#cifs_winrsAllowDelegate">the online documentation</a>
      */

--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
@@ -68,6 +68,10 @@ import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_LOCALE;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_TIMEMOUT;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_KERBEROS_TICKET_CACHE;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_KERBEROS_TICKET_CACHE_DEFAULT;
+import static com.xebialabs.overthere.ConnectionOptions.CONNECTION_TIMEOUT_MILLIS;
+import static com.xebialabs.overthere.ConnectionOptions.CONNECTION_TIMEOUT_MILLIS_DEFAULT;
+import static com.xebialabs.overthere.ConnectionOptions.SO_TIMEOUT_MILLIS;
+import static com.xebialabs.overthere.ConnectionOptions.SO_TIMEOUT_MILLIS_DEFAULT;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
 import static java.lang.String.format;
 
@@ -248,6 +252,8 @@ public class CifsWinRmConnection extends CifsConnection {
         client.setKerberosAddPortToSpn(options.getBoolean(WINRM_KERBEROS_ADD_PORT_TO_SPN, WINRM_KERBEROS_ADD_PORT_TO_SPN_DEFAULT));
         client.setKerberosDebug(options.getBoolean(WINRM_KERBEROS_DEBUG, WINRM_KERBEROS_DEBUG_DEFAULT));
         client.setKerberosTicketCache(options.getBoolean(WINRM_KERBEROS_TICKET_CACHE, WINRM_KERBEROS_TICKET_CACHE_DEFAULT));
+        client.setConnectionTimeout(options.getInteger(CONNECTION_TIMEOUT_MILLIS, CONNECTION_TIMEOUT_MILLIS_DEFAULT));
+        client.setSoTimeout(options.getInteger(SO_TIMEOUT_MILLIS, SO_TIMEOUT_MILLIS_DEFAULT));
         return client;
     }
 

--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
@@ -68,10 +68,10 @@ import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_LOCALE;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_TIMEMOUT;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_KERBEROS_TICKET_CACHE;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_KERBEROS_TICKET_CACHE_DEFAULT;
+import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_SO_TIMEOUT_MILLIS;
+import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_SO_TIMEOUT_MILLIS_DEFAULT;
 import static com.xebialabs.overthere.ConnectionOptions.CONNECTION_TIMEOUT_MILLIS;
 import static com.xebialabs.overthere.ConnectionOptions.CONNECTION_TIMEOUT_MILLIS_DEFAULT;
-import static com.xebialabs.overthere.ConnectionOptions.SO_TIMEOUT_MILLIS;
-import static com.xebialabs.overthere.ConnectionOptions.SO_TIMEOUT_MILLIS_DEFAULT;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
 import static java.lang.String.format;
 
@@ -253,7 +253,7 @@ public class CifsWinRmConnection extends CifsConnection {
         client.setKerberosDebug(options.getBoolean(WINRM_KERBEROS_DEBUG, WINRM_KERBEROS_DEBUG_DEFAULT));
         client.setKerberosTicketCache(options.getBoolean(WINRM_KERBEROS_TICKET_CACHE, WINRM_KERBEROS_TICKET_CACHE_DEFAULT));
         client.setConnectionTimeout(options.getInteger(CONNECTION_TIMEOUT_MILLIS, CONNECTION_TIMEOUT_MILLIS_DEFAULT));
-        client.setSoTimeout(options.getInteger(SO_TIMEOUT_MILLIS, SO_TIMEOUT_MILLIS_DEFAULT));
+        client.setSoTimeout(options.getInteger(WINRM_SO_TIMEOUT_MILLIS, WINRM_SO_TIMEOUT_MILLIS_DEFAULT));
         return client;
     }
 

--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/WinRmClient.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/WinRmClient.java
@@ -64,6 +64,7 @@ import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.dom4j.Document;
@@ -116,6 +117,8 @@ public class WinRmClient {
     private boolean kerberosAddPortToSpn;
     private boolean kerberosDebug;
     private boolean kerberosTicketCache;
+    private int soTimeout;
+    private int connectionTimeout;
 
     private String shellId;
     private String commandId;
@@ -454,6 +457,9 @@ public class WinRmClient {
         }
 
         httpclient.getParams().setBooleanParameter(HANDLE_AUTHENTICATION, true);
+
+        HttpConnectionParams.setSoTimeout(httpclient.getParams(), soTimeout);
+        HttpConnectionParams.setConnectionTimeout(httpclient.getParams(), connectionTimeout);
     }
 
     private void configureTrust(final DefaultHttpClient httpclient) throws NoSuchAlgorithmException,
@@ -593,6 +599,26 @@ public class WinRmClient {
     
     public void setKerberosTicketCache(boolean kerberosTicketCache) {
         this.kerberosTicketCache = kerberosTicketCache;
+    }
+
+    public int getConnectionTimeout ()
+    {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout ( int connectionTimeout )
+    {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public int getSoTimeout ()
+    {
+        return soTimeout;
+    }
+
+    public void setSoTimeout ( int soTimeout )
+    {
+        this.soTimeout = soTimeout;
     }
 
     private static Logger logger = LoggerFactory.getLogger(WinRmClient.class);


### PR DESCRIPTION
Hi,

I had discovered that in the underlaying http client of the WinRM client, the connection timeout wasn't injected, and I've also added support for socket timeout.

Probably it will fixes also problems reported in #118 