### PR TITLE
Added support for socket timeout in SshConnection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ Apart from selecting a protocol to use, you will also need to supply a number of
 	    2 minutes.</td>
 </tr>
 <tr>
+	<th align="left" valign="top"><a name="socketTimeoutMillis"></a>socketTimeoutMillis</th>
+	<td>The number of milliseconds Overthere will waits when no data is received on an open connection before raising exception. The default value is <code>0</code>, i.e.
+	    infinite timeout.</td>
+</tr>
+<tr>
 	<th align="left" valign="top"><a name="jumpstation"></a>jumpstation</th>
 	<td>If set to a non-null value, this property contains the connection options used to connect to an SSH jumpstation (See
 	    <a href="#tunnelling">Tunnelling</a>). Recursive configuration is possible, i.e. this property is also available for the connection options of a
@@ -987,10 +992,6 @@ The CIFS protocol implementation of Overthere defines a number of additional con
 	<td>The WinRM timeout to use in <a href="http://www.w3.org/TR/xmlschema-2/#isoformats">XML schema duration format</a>. The default value is <code>PT60.000S</code>.
 	<br/>
 	<strong>N.B.:</strong> This connection option is only applicable for the <strong>WINRM_INTERNAL</strong> connection type.</td>
-</tr>
-<tr>
-	<th align="left" valign="top"><a name="winrmSoTimeoutMillis"></a>winrmSoTimeoutMillis</th>
-	<td>The number of milliseconds Overthere will waits when no data is received on an open connection before raising exception. The default value is <code>0</code>, meaning that read operations will not time out (infinite timeout).</td>
 </tr>
 <tr>
 	<th align="left" valign="top"><a name="cifs_winrsAllowDelegate"></a>winrsAllowDelegate</th>

--- a/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
+++ b/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
@@ -72,6 +72,16 @@ public class ConnectionOptions {
      */
     public static final int CONNECTION_TIMEOUT_MILLIS_DEFAULT = 120000;
 
+	/**
+	 * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#socketTimeoutMillis">the online documentation</a>
+	 */
+	public static final String SOCKET_TIMEOUT_MILLIS = "socketTimeoutMillis";
+
+	/**
+	 * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#socketTimeoutMillis">the online documentation</a>
+	 */
+	public static final int SOCKET_TIMEOUT_MILLIS_DEFAULT = 0;
+
     /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#address">the online documentation</a>
      */

--- a/src/main/java/com/xebialabs/overthere/cifs/CifsConnectionBuilder.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/CifsConnectionBuilder.java
@@ -200,16 +200,6 @@ public class CifsConnectionBuilder implements OverthereConnectionBuilder {
      */
     public static final String DEFAULT_WINRM_TIMEOUT = "PT60.000S";
 
-	/**
-	 * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#winrmSoTimeoutMillis">the online documentation</a>
-	 */
-	public static final String WINRM_SO_TIMEOUT_MILLIS = "winrmSoTimeoutMillis";
-
-	/**
-	 * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#soTimeoutMillis">the online documentation</a>
-	 */
-	public static final int WINRM_SO_TIMEOUT_MILLIS_DEFAULT = 0;
-
     /**
      * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#cifs_winrsAllowDelegate">the online documentation</a>
      */

--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/CifsWinRmConnection.java
@@ -42,6 +42,7 @@ import com.xebialabs.overthere.cifs.WinrmHttpsCertificateTrustStrategy;
 import com.xebialabs.overthere.cifs.WinrmHttpsHostnameVerificationStrategy;
 import com.xebialabs.overthere.spi.AddressPortMapper;
 
+import static com.xebialabs.overthere.ConnectionOptions.*;
 import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
 import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
@@ -68,8 +69,6 @@ import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_LOCALE;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_TIMEMOUT;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_KERBEROS_TICKET_CACHE;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_KERBEROS_TICKET_CACHE_DEFAULT;
-import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_SO_TIMEOUT_MILLIS;
-import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.WINRM_SO_TIMEOUT_MILLIS_DEFAULT;
 import static com.xebialabs.overthere.ConnectionOptions.CONNECTION_TIMEOUT_MILLIS;
 import static com.xebialabs.overthere.ConnectionOptions.CONNECTION_TIMEOUT_MILLIS_DEFAULT;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
@@ -253,7 +252,7 @@ public class CifsWinRmConnection extends CifsConnection {
         client.setKerberosDebug(options.getBoolean(WINRM_KERBEROS_DEBUG, WINRM_KERBEROS_DEBUG_DEFAULT));
         client.setKerberosTicketCache(options.getBoolean(WINRM_KERBEROS_TICKET_CACHE, WINRM_KERBEROS_TICKET_CACHE_DEFAULT));
         client.setConnectionTimeout(options.getInteger(CONNECTION_TIMEOUT_MILLIS, CONNECTION_TIMEOUT_MILLIS_DEFAULT));
-        client.setSoTimeout(options.getInteger(WINRM_SO_TIMEOUT_MILLIS, WINRM_SO_TIMEOUT_MILLIS_DEFAULT));
+        client.setSoTimeout(options.getInteger(SOCKET_TIMEOUT_MILLIS, SOCKET_TIMEOUT_MILLIS_DEFAULT));
         return client;
     }
 

--- a/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
+++ b/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
@@ -66,6 +66,7 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
     protected final AddressPortMapper mapper;
     protected final OperatingSystemFamily os;
     protected final int connectionTimeoutMillis;
+    protected final int socketTimeoutMillis;
     protected final boolean canStartProcess;
     protected final String temporaryDirectoryPath;
     protected final boolean deleteTemporaryDirectoryOnDisconnect;
@@ -85,6 +86,7 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
         this.mapper = checkNotNull(mapper, "Cannot create OverthereConnection with null address-port mapper");
         this.os = options.getEnum(OPERATING_SYSTEM, OperatingSystemFamily.class);
         this.connectionTimeoutMillis = options.getInteger(CONNECTION_TIMEOUT_MILLIS, CONNECTION_TIMEOUT_MILLIS_DEFAULT);
+        this.socketTimeoutMillis = options.getInteger(SOCKET_TIMEOUT_MILLIS, SOCKET_TIMEOUT_MILLIS_DEFAULT);
         this.canStartProcess = canStartProcess;
         this.temporaryDirectoryPath = options.get(TEMPORARY_DIRECTORY_PATH, os.getDefaultTemporaryDirectoryPath());
         this.deleteTemporaryDirectoryOnDisconnect = options.getBoolean(TEMPORARY_DIRECTORY_DELETE_ON_DISCONNECT, TEMPORARY_DIRECTORY_DELETE_ON_DISCONNECT_DEFAULT);

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
@@ -140,6 +140,7 @@ abstract class SshConnection extends BaseOverthereConnection {
             SSHClient client = sshClientFactory.create();
             client.setConnectTimeout(connectionTimeoutMillis);
             client.addHostKeyVerifier(new PromiscuousVerifier());
+            client.setTimeout(socketTimeoutMillis);
             client.getConnection().getKeepAlive().setKeepAliveInterval(heartbeatInterval);
 
             try {


### PR DESCRIPTION
This is the same feature I've added in the previously PR for winrm, this time for the ssh client (I don't know if we are particularly unlucky but we are getting tons of random network errors while using this library).

For this reason I've uniformed the parameter in a more generic socketTimeoutMillis.