### PR TITLE
build.gradle: disable xdoclint for java 8 to avoid unlimited javadoc validation errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,14 @@ configurations {
   }
 }
 
+if (JavaVersion.current().isJava8Compatible()) {
+  allprojects {
+    tasks.withType(Javadoc) {
+      options.addStringOption('Xdoclint:none', '-quiet')
+    }
+  }
+}
+
 dependencies {
   // General dependencies
   compile 'nl.javadude.scannit:scannit:1.3.1'


### PR DESCRIPTION
A workaroud for:

```
37 errors
34 warnings
:javadoc FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':javadoc'.
> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '/home/gionn/src/overthere/build/tmp/javadoc/javadoc.options'

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```

when using jdk8.