### PR TITLE
DEPL-8399: CifsFile.getParentFile method should return null if there is no real parent (share)

### DIFF
--- a/src/main/java/com/xebialabs/overthere/cifs/CifsFile.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/CifsFile.java
@@ -28,15 +28,16 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
+
+import jcifs.smb.SmbException;
+import jcifs.smb.SmbFile;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.xebialabs.overthere.OverthereFile;
 import com.xebialabs.overthere.RuntimeIOException;
 import com.xebialabs.overthere.spi.BaseOverthereFile;
-
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
 
 import static java.lang.String.format;
 
@@ -67,10 +68,12 @@ class CifsFile extends BaseOverthereFile<CifsConnection> {
     public OverthereFile getParentFile() {
         try {
             String parent = smbFile.getParent();
-            if (connection.encoder.isValidUncPath(parent)) {
-                return new CifsFile(getConnection(), new SmbFile(parent, connection.authentication));
+            SmbFile parentSmbFile = new SmbFile(parent, connection.authentication);
+            String share = parentSmbFile.getShare();
+            if (null == share) {
+                return null;
             }
-            return null;
+            return new CifsFile(getConnection(), parentSmbFile);
         } catch (MalformedURLException exc) {
             return null;
         }

--- a/src/test/java/com/xebialabs/overthere/cifs/CifsFileTest.java
+++ b/src/test/java/com/xebialabs/overthere/cifs/CifsFileTest.java
@@ -1,20 +1,28 @@
 package com.xebialabs.overthere.cifs;
 
-import com.xebialabs.overthere.ConnectionOptions;
-import com.xebialabs.overthere.OverthereFile;
-import com.xebialabs.overthere.cifs.winrm.CifsWinRmConnection;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static com.xebialabs.overthere.ConnectionOptions.*;
+import com.xebialabs.overthere.ConnectionOptions;
+import com.xebialabs.overthere.OverthereFile;
+import com.xebialabs.overthere.cifs.winrm.CifsWinRmConnection;
+
+import static com.xebialabs.overthere.ConnectionOptions.ADDRESS;
+import static com.xebialabs.overthere.ConnectionOptions.OPERATING_SYSTEM;
+import static com.xebialabs.overthere.ConnectionOptions.PASSWORD;
+import static com.xebialabs.overthere.ConnectionOptions.PORT;
+import static com.xebialabs.overthere.ConnectionOptions.USERNAME;
 import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
-import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.*;
+import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.CIFS_PORT;
+import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.CIFS_PORT_DEFAULT;
+import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.CIFS_PROTOCOL;
+import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.CONNECTION_TYPE;
+import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.PORT_DEFAULT_WINRM_HTTP;
 import static com.xebialabs.overthere.cifs.CifsConnectionType.WINRM_INTERNAL;
 import static com.xebialabs.overthere.util.DefaultAddressPortMapper.INSTANCE;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.testng.Assert.*;
 
 public class CifsFileTest {
 
@@ -38,6 +46,14 @@ public class CifsFileTest {
         CifsWinRmConnection cifsWinRmConnection = new CifsWinRmConnection(CIFS_PROTOCOL, options, INSTANCE);
         OverthereFile file = cifsWinRmConnection.getFile("C:\\");
         assertThat(file.getParentFile(), nullValue());
+    }
+
+    @Test
+    public void shouldSucceedForNonRoot() {
+        options.set(USERNAME, "user@domain.com");
+        CifsWinRmConnection cifsWinRmConnection = new CifsWinRmConnection(CIFS_PROTOCOL, options, INSTANCE);
+        OverthereFile file = cifsWinRmConnection.getFile("C:\\windows\\temp\\ot-2015060");
+        assertThat(file.getParentFile(), not(nullValue()));
     }
 
 


### PR DESCRIPTION
See https://github.com/xebialabs/overthere/issues/153 and DEPL-8399

