### PR TITLE
Copying to SFTP is very slow compared to native/SSHJ

### DIFF
--- a/src/main/java/com/xebialabs/overthere/ssh/OverthereFileLocalSourceFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/OverthereFileLocalSourceFile.java
@@ -1,0 +1,77 @@
+package com.xebialabs.overthere.ssh;
+
+import com.xebialabs.overthere.OverthereFile;
+import net.schmizz.sshj.xfer.LocalFileFilter;
+import net.schmizz.sshj.xfer.LocalSourceFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Wrapper for the LocalSourceFile supplied by SSHJ.
+ */
+class OverthereFileLocalSourceFile implements LocalSourceFile {
+
+    private OverthereFile f;
+
+    public OverthereFileLocalSourceFile(OverthereFile f) {
+        this.f = f;
+    }
+
+    @Override
+    public String getName() {
+        return f.getName();
+    }
+
+    @Override
+    public long getLength() {
+        return f.length();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return f.getInputStream();
+    }
+
+    @Override
+    public int getPermissions() throws IOException {
+        return f.isDirectory() ? 0755 : 0644;
+    }
+
+    @Override
+    public boolean isFile() {
+        return f.isFile();
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return f.isDirectory();
+    }
+
+    @Override
+    public Iterable<? extends LocalSourceFile> getChildren(LocalFileFilter filter) throws IOException {
+        List<LocalSourceFile> files = new ArrayList<LocalSourceFile>();
+        for (OverthereFile each : f.listFiles()) {
+            files.add(new OverthereFileLocalSourceFile(each));
+        }
+        return files;
+    }
+
+    @Override
+    public boolean providesAtimeMtime() {
+        return false;
+    }
+
+    @Override
+    public long getLastAccessTime() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public long getLastModifiedTime() throws IOException {
+        return 0;
+    }
+
+}

--- a/src/main/java/com/xebialabs/overthere/ssh/SshScpFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshScpFile.java
@@ -22,28 +22,20 @@
  */
 package com.xebialabs.overthere.ssh;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import com.xebialabs.overthere.CmdLine;
+import com.xebialabs.overthere.OverthereFile;
+import com.xebialabs.overthere.RuntimeIOException;
+import com.xebialabs.overthere.util.CapturingOverthereExecutionOutputHandler;
+import net.schmizz.sshj.xfer.scp.SCPUploadClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.xebialabs.overthere.CmdLine;
-import com.xebialabs.overthere.OverthereFile;
-import com.xebialabs.overthere.RuntimeIOException;
-import com.xebialabs.overthere.util.CapturingOverthereExecutionOutputHandler;
-
-import net.schmizz.sshj.xfer.LocalFileFilter;
-import net.schmizz.sshj.xfer.LocalSourceFile;
-import net.schmizz.sshj.xfer.scp.SCPUploadClient;
 
 import static com.xebialabs.overthere.CmdLine.build;
 import static com.xebialabs.overthere.ssh.SshConnection.NOCD_PSEUDO_COMMAND;
@@ -385,70 +377,6 @@ class SshScpFile extends SshFile<SshScpConnection> {
         if (errno != 0) {
             throw new RuntimeIOException(format("%s: %s (errno=%d)", message, capturedStderr.getOutput(), errno));
         }
-    }
-
-    protected static class OverthereFileLocalSourceFile implements LocalSourceFile {
-
-        private OverthereFile f;
-
-        public OverthereFileLocalSourceFile(OverthereFile f) {
-            this.f = f;
-        }
-
-        @Override
-        public String getName() {
-            return f.getName();
-        }
-
-        @Override
-        public long getLength() {
-            return f.length();
-        }
-
-        @Override
-        public InputStream getInputStream() throws IOException {
-            return f.getInputStream();
-        }
-
-        @Override
-        public int getPermissions() throws IOException {
-            return f.isDirectory() ? 0755 : 0644;
-        }
-
-        @Override
-        public boolean isFile() {
-            return f.isFile();
-        }
-
-        @Override
-        public boolean isDirectory() {
-            return f.isDirectory();
-        }
-
-        @Override
-        public Iterable<? extends LocalSourceFile> getChildren(LocalFileFilter filter) throws IOException {
-            List<LocalSourceFile> files = new ArrayList<LocalSourceFile>();
-            for (OverthereFile each : f.listFiles()) {
-                files.add(new OverthereFileLocalSourceFile(each));
-            }
-            return files;
-        }
-
-        @Override
-        public boolean providesAtimeMtime() {
-            return false;
-        }
-
-        @Override
-        public long getLastAccessTime() throws IOException {
-            return 0;
-        }
-
-        @Override
-        public long getLastModifiedTime() throws IOException {
-            return 0;
-        }
-
     }
 
     private static Logger logger = LoggerFactory.getLogger(SshScpFile.class);

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpFile.java
@@ -137,6 +137,24 @@ class SshSftpFile extends SshFile<SshSftpConnection> {
     }
 
     @Override
+    protected void copyFrom(OverthereFile source) {
+        SFTPFileTransfer fileTransfer = connection.getSharedSftpClient().getFileTransfer();
+        try {
+            // If the source is a directory and the name and the target name do not match, SFTP copies the
+            // directory into the destination, whereas we want to copy the contents into the destination.
+            if (source.isDirectory() && this.exists() && !source.getName().equals(this.getName())) {
+                for (OverthereFile overthereFile : source.listFiles()) {
+                    fileTransfer.upload(new OverthereFileLocalSourceFile(overthereFile), getPath());
+                }
+            } else {
+                fileTransfer.upload(new OverthereFileLocalSourceFile(source), getPath());
+            }
+        } catch (IOException ioe) {
+            throw new RuntimeIOException(format("Cannot upload %s to %s", source, this), ioe);
+        }
+    }
+
+    @Override
     public void mkdir() {
         logger.debug("Creating directory {}", this);
 

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpFile.java
@@ -144,10 +144,10 @@ class SshSftpFile extends SshFile<SshSftpConnection> {
             // directory into the destination, whereas we want to copy the contents into the destination.
             if (source.isDirectory() && this.exists() && !source.getName().equals(this.getName())) {
                 for (OverthereFile overthereFile : source.listFiles()) {
-                    fileTransfer.upload(new OverthereFileLocalSourceFile(overthereFile), getPath());
+                    fileTransfer.upload(new OverthereFileLocalSourceFile(overthereFile), getSftpPath());
                 }
             } else {
-                fileTransfer.upload(new OverthereFileLocalSourceFile(source), getPath());
+                fileTransfer.upload(new OverthereFileLocalSourceFile(source), getSftpPath());
             }
         } catch (IOException ioe) {
             throw new RuntimeIOException(format("Cannot upload %s to %s", source, this), ioe);


### PR DESCRIPTION
When copying files from local to SFTP, Overthere is twice slower than either native `ssh` or using `SSHJ` directly.

This PR fixes #164 (and is the correct version of #165)