### PR TITLE
Extended Distinction between IBM JRE and Others

### DIFF
--- a/src/main/java/com/xebialabs/overthere/cifs/winrm/KerberosJaasConfiguration.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/winrm/KerberosJaasConfiguration.java
@@ -49,20 +49,26 @@ class KerberosJaasConfiguration extends Configuration {
             options.put("debug", "true");
         }
         
-        if (ticketCache) {
-        	options.put("useTicketCache", "true");
-        } else {
-        	options.put("useTicketCache", "false");
-        }
-        
         options.put("refreshKrb5Config", "true");
         
         if (JavaVendor.isIBM()) {
             options.put("credsType", "initiator");
+            
+            if (ticketCache) {
+            	options.put("useDefaultCcache", "true");
+            } else {
+            	options.put("useDefaultCcache", "false");
+            }
         } else {
             options.put("client", "true");
             options.put("useKeyTab", "false");
             options.put("doNotPrompt", "false");
+            
+            if (ticketCache) {
+            	options.put("useTicketCache", "true");
+            } else {
+            	options.put("useTicketCache", "false");
+            }
         }
 
         return new AppConfigurationEntry[]{new AppConfigurationEntry(JavaVendor.getKrb5LoginModuleName(),


### PR DESCRIPTION
The JAAS property useTicketCache is not known to IBM JRE, instead the
property useDefaultCcache [sic!] is used.