### PR TITLE
Fixed remote powershell permission denied with cygwin ssh.

### DIFF
--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpConnection.java
@@ -51,8 +51,6 @@ abstract class SshSftpConnection extends SshConnection {
     @Override
     protected void connect() {
         super.connect();
-
-        sharedSftpClient = connectSftp();
     }
 
     @Override
@@ -73,6 +71,9 @@ abstract class SshSftpConnection extends SshConnection {
     }
 
     SFTPClient getSharedSftpClient() {
+        if ( sharedSftpClient == null ) {
+            sharedSftpClient = connectSftp();
+        }
         return sharedSftpClient;
     }
 


### PR DESCRIPTION
Found a bug during running a remote powershell command that did Get-DnsServerZone and Add-DnsServerResourceRecord commands via cygwin ssh
that returned permission denied.  Created a test app with just sshj and found that sshj worked fine, and after stepping through the code,
I found that it appeared that the startProcess commands would run on session 1 vs session 0, which should
have been the SFTP connection session.   Found if I moved the sharedSftpClient = connectSftp() to the getSharedSftpClient() instead of the
connect the issue was resolved and the powershell seemed to work as expected and how it works under WinSSHD.

Additionally it seems that you would not want to start two connections anyway, unless they were going to be used, if one does not use any of
the file commands, but just executes a process the additional connection is not needed.

I have tested using SFTP prior to and after startProcess and see no adverse affects to the move, yet it now seems to work as expected.
This change was testing in the 4.2.1 release and the 4.3.1-snapshot with WinSSHD and CygwinSSH