### PR TITLE
Log the SOAP's body of the response from WinRM in case of error

### DIFF
--- a/src/main/java/com/xebialabs/overthere/winrm/WinRmClient.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WinRmClient.java
@@ -415,15 +415,21 @@ class WinRmClient {
 
                 logResponseHeaders(response);
 
+                Document responseDocument = null;
+                try {
+                    final String responseBody = handleResponse(response, context);
+                    responseDocument = DocumentHelper.parseText(responseBody);
+                    logDocument("Response body:", responseDocument);
+                } catch(WinRmRuntimeIOException e) {
+                    if (response.getStatusLine().getStatusCode() == 200) {
+                    	throw e;
+                    }
+                }
+                
                 if (response.getStatusLine().getStatusCode() != 200) {
                     throw new WinRmRuntimeIOException(String.format("Unexpected HTTP response on %s:  %s (%s)",
                             targetURL, response.getStatusLine().getReasonPhrase(), response.getStatusLine().getStatusCode()));
                 }
-
-                final String responseBody = handleResponse(response, context);
-                Document responseDocument = DocumentHelper.parseText(responseBody);
-
-                logDocument("Response body:", responseDocument);
 
                 return responseDocument;
             } finally {


### PR DESCRIPTION
Hello,

The SOAP response is logged only if the response is OK.
But when the WinRM service returns an error (for example a 500) the body of the SOAP response may contain a `<Fault>` tag with a child tag `<Reason>` with a detailed message which explains the cause of the error.
This message can be very helpful to troubleshooting the error (for example in me case the message explained that the quota limit for opened shells was exceeded).

Example of response:
```xml
<s:Envelope >
  <s:Header>
  .../...
  </s:Header>
  <s:Body>
    <s:Fault>
      <s:Code>
        <s:Value>s:Sender</s:Value>
        <s:Subcode>
          <s:Value>w:QuotaLimit</s:Value>
        </s:Subcode>
      </s:Code>
      <s:Reason>
        <s:Text>The WS-Management service cannot process the request. The maximum number of concurrent shells for this user has been exceeded. Close existing shells or raise the quota for this user.</s:Text>
      </s:Reason>
      <s:Detail>
.../...
      </s:Detail>
    </s:Fault>
  </s:Body>
</s:Envelope> 
```

Eric