### PR TITLE
DEPl-11533 - XLD 605 logging behaviour seems to have changed as compared to 514

### DIFF
--- a/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
+++ b/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
@@ -315,7 +315,7 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
             @Override
             public void run() {
                 Map<String, String> previous = MDC.getCopyOfContextMap();
-                mdcFromParentContext(mdcContext);
+                setMDCContext(mdcContext);
                 StringBuilder lineBuffer = new StringBuilder();
                 InputStreamReader stdoutReader = new InputStreamReader(stream);
                 latch.countDown();
@@ -340,23 +340,15 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
                     if (lineBuffer.length() > 0) {
                         outputHandler.handleLine(lineBuffer.toString());
                     }
-                    restoreMDCContext(previous);
+                    setMDCContext(previous);
                 }
             }
 
-            private void restoreMDCContext(Map<String, String> previous) {
-                if (previous == null) {
+            private void setMDCContext(Map<String, String> context) {
+                if (context == null) {
                     MDC.clear();
                 } else {
-                    MDC.setContextMap(previous);
-                }
-            }
-
-            private void mdcFromParentContext(Map<String, String> mdcParent) {
-                if (mdcParent == null) {
-                    MDC.clear();
-                } else {
-                    MDC.setContextMap(mdcParent);
+                    MDC.setContextMap(context);
                 }
             }
         };

--- a/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
+++ b/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
@@ -315,7 +315,7 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
             @Override
             public void run() {
                 Map<String, String> previous = MDC.getCopyOfContextMap();
-                mdcFromParentContext();
+                mdcFromParentContext(mdcContext);
                 StringBuilder lineBuffer = new StringBuilder();
                 InputStreamReader stdoutReader = new InputStreamReader(stream);
                 latch.countDown();
@@ -352,11 +352,11 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
                 }
             }
 
-            private void mdcFromParentContext() {
-                if (mdcContext == null) {
+            private void mdcFromParentContext(Map<String, String> mdcParent) {
+                if (mdcParent == null) {
                     MDC.clear();
                 } else {
-                    MDC.setContextMap(mdcContext);
+                    MDC.setContextMap(mdcParent);
                 }
             }
         };


### PR DESCRIPTION
The issue is with logback version we are using -> The child thread does not automatically inherit the MDC of its parent. 
Though this was working with the logback version 1.1.3 in xl-deploy-5.1.x.
The current version of logback is 1.2.2

Reference link - https://logback.qos.ch/manual/mdc.html
