### PR TITLE
Introduction of the parameter "useCanonicalName" which  in the Apache…

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ __N.B.:__ You will only need to configure Kerberos if you are going to use Windo
 By default, Overthere 2.1.0 and up will request access to a Kerberos <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/ms677949(v=vs.85).aspx">service principal name</a> of the form <code>WSMAN/<em>HOST</em></code>, for which an SPN should be configured automatically when you [configure WinRM for a remote host](#smb_cifs_host_setup_winrm).
 
 If that was not configured correctly, if you have overridden the default SPN for which a ticket is requested through the [__winrmKerberosAddPortToSpn__](#smb_cifs_winrmKerberosAddPortToSpn) or the [__winrmKerberosUseHttpSpn__](#smb_cifs_winrmKerberosUseHttpSpn) connection properties, or if you are running an older version of Overthere, you will have configure the service principal names manually.
+The parameter [__winrmUseCanonicalHostname__](#smb_cifs_winrmUseCanonicalHostname) can be used to use the remote host FQDN provided by the DNS.  
 
 This can be achieved by invoking the <a href="http://technet.microsoft.com/en-us/library/cc731241(v=ws.10).aspx">setspn</a> command, as an Administrator, on any host in the domain, as follows:
 <pre>

--- a/src/main/java/com/xebialabs/overthere/cifs/BaseCifsConnectionBuilder.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/BaseCifsConnectionBuilder.java
@@ -236,4 +236,13 @@ public abstract class BaseCifsConnectionBuilder {
      */
     public static final Map<String, String> PATH_SHARE_MAPPINGS_DEFAULT = Collections.emptyMap();
 
+    /**
+     * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#smb_cifs_winrmUseCanonicalHostname">the online documentation</a>
+     */
+    public static final String WINRM_USE_CANONICAL_HOSTNAME = "winrmUseCanonicalHostname";
+
+    /**
+     * See <a href="https://github.com/xebialabs/overthere/blob/master/README.md#smb_cifs_winrmUseCanonicalHostname">the online documentation</a>
+     */
+    public static final boolean WINRM_USE_CANONICAL_HOSTNAME_DEFAULT = false;
 }

--- a/src/main/java/com/xebialabs/overthere/winrm/WinRmClient.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WinRmClient.java
@@ -109,6 +109,7 @@ class WinRmClient {
     private boolean kerberosTicketCache;
     private int soTimeout;
     private int connectionTimeout;
+    private boolean useCanonicalHostname;
 
     private String shellId;
     private String commandId;
@@ -467,8 +468,8 @@ class WinRmClient {
         if (enableKerberos) {
             String spnServiceClass = kerberosUseHttpSpn ? "HTTP" : "WSMAN";
             RegistryBuilder<AuthSchemeProvider> authSchemeRegistryBuilder = RegistryBuilder.create();
-            authSchemeRegistryBuilder.register(KERBEROS, new WsmanKerberosSchemeFactory(!kerberosAddPortToSpn, spnServiceClass, unmappedAddress, unmappedPort));
-            authSchemeRegistryBuilder.register(SPNEGO, new WsmanSPNegoSchemeFactory(!kerberosAddPortToSpn, spnServiceClass, unmappedAddress, unmappedPort));
+            authSchemeRegistryBuilder.register(KERBEROS, new WsmanKerberosSchemeFactory(!kerberosAddPortToSpn, spnServiceClass, unmappedAddress, unmappedPort, useCanonicalHostname));
+            authSchemeRegistryBuilder.register(SPNEGO, new WsmanSPNegoSchemeFactory(!kerberosAddPortToSpn, spnServiceClass, unmappedAddress, unmappedPort, useCanonicalHostname));
             httpclient.setDefaultAuthSchemeRegistry(authSchemeRegistryBuilder.build());
             configureAuthentication(credentialsProvider, KERBEROS, new KerberosPrincipal(username));
             configureAuthentication(credentialsProvider, SPNEGO, new KerberosPrincipal(username));
@@ -635,6 +636,15 @@ class WinRmClient {
     public void setSoTimeout ( int soTimeout )
     {
         this.soTimeout = soTimeout;
+    }
+
+
+    public boolean isUseCanonicalHostname() {
+        return useCanonicalHostname;
+    }
+
+    public void setUseCanonicalHostname(boolean useCanonicalHostname) {
+        this.useCanonicalHostname = useCanonicalHostname;
     }
 
     private static Logger logger = LoggerFactory.getLogger(WinRmClient.class);

--- a/src/main/java/com/xebialabs/overthere/winrm/WinRmConnection.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WinRmConnection.java
@@ -266,6 +266,7 @@ public class WinRmConnection implements ProcessConnection {
         client.setKerberosTicketCache(options.getBoolean(WINRM_KERBEROS_TICKET_CACHE, WINRM_KERBEROS_TICKET_CACHE_DEFAULT));
         client.setConnectionTimeout(connectionTimeoutMillis);
         client.setSoTimeout(socketTimeoutMillis);
+        client.setUseCanonicalHostname(options.getBoolean(WINRM_USE_CANONICAL_HOSTNAME, WINRM_USE_CANONICAL_HOSTNAME_DEFAULT));
         return client;
     }
 

--- a/src/main/java/com/xebialabs/overthere/winrm/WsmanKerberosScheme.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WsmanKerberosScheme.java
@@ -22,6 +22,7 @@
  */
 package com.xebialabs.overthere.winrm;
 
+import com.xebialabs.overthere.cifs.BaseCifsConnectionBuilder;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.KerberosCredentials;
 import org.apache.http.impl.auth.KerberosScheme;
@@ -43,7 +44,11 @@ class WsmanKerberosScheme extends KerberosScheme {
     private final int spnPort;
 
     public WsmanKerberosScheme(final boolean stripPort, final String spnServiceClass, final String spnAddress, final int spnPort) {
-        super(stripPort);
+        this(stripPort, spnServiceClass, spnAddress, spnPort, BaseCifsConnectionBuilder.WINRM_USE_CANONICAL_HOSTNAME_DEFAULT);
+    }
+
+    public WsmanKerberosScheme(final boolean stripPort, final String spnServiceClass, final String spnAddress, final int spnPort, final boolean useCanonicalHostname) {
+        super(stripPort, useCanonicalHostname);
         this.spnServiceClass = spnServiceClass;
         this.spnAddress = spnAddress;
         this.spnPort = spnPort;

--- a/src/main/java/com/xebialabs/overthere/winrm/WsmanKerberosSchemeFactory.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WsmanKerberosSchemeFactory.java
@@ -22,6 +22,7 @@
  */
 package com.xebialabs.overthere.winrm;
 
+import com.xebialabs.overthere.cifs.BaseCifsConnectionBuilder;
 import org.apache.http.auth.AuthScheme;
 import org.apache.http.impl.auth.KerberosSchemeFactory;
 import org.apache.http.params.HttpParams;
@@ -37,11 +38,18 @@ class WsmanKerberosSchemeFactory extends KerberosSchemeFactory {
 
     private final int spnPort;
 
+    private final boolean useCanonicalHostname;
+
     public WsmanKerberosSchemeFactory(final boolean stripPort, final String spnServiceClass, final String spnHost, final int spnPort) {
-        super(stripPort);
+        this(stripPort, spnServiceClass, spnHost, spnPort, BaseCifsConnectionBuilder.WINRM_USE_CANONICAL_HOSTNAME_DEFAULT);
+    }
+
+    public WsmanKerberosSchemeFactory(final boolean stripPort, final String spnServiceClass, final String spnHost, final int spnPort, final boolean useCanonicalHostname) {
+        super(stripPort, useCanonicalHostname);
         this.spnServiceClass = spnServiceClass;
         this.spnHost = spnHost;
         this.spnPort = spnPort;
+        this.useCanonicalHostname = useCanonicalHostname;
     }
 
     @Override

--- a/src/main/java/com/xebialabs/overthere/winrm/WsmanSPNegoScheme.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WsmanSPNegoScheme.java
@@ -22,6 +22,7 @@
  */
 package com.xebialabs.overthere.winrm;
 
+import com.xebialabs.overthere.cifs.BaseCifsConnectionBuilder;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.KerberosCredentials;
 import org.apache.http.impl.auth.SPNegoScheme;
@@ -43,7 +44,11 @@ class WsmanSPNegoScheme extends SPNegoScheme {
     private final int spnPort;
 
     public WsmanSPNegoScheme(final boolean stripPort, final String spnServiceClass, final String spnAddress, final int spnPort) {
-        super(stripPort);
+        this(stripPort, spnServiceClass, spnAddress, spnPort, BaseCifsConnectionBuilder.WINRM_USE_CANONICAL_HOSTNAME_DEFAULT);
+    }
+
+    public WsmanSPNegoScheme(final boolean stripPort, final String spnServiceClass, final String spnAddress, final int spnPort, final boolean useCanonicalHostname) {
+        super(stripPort, useCanonicalHostname);
         this.spnServiceClass = spnServiceClass;
         this.spnAddress = spnAddress;
         this.spnPort = spnPort;

--- a/src/main/java/com/xebialabs/overthere/winrm/WsmanSPNegoSchemeFactory.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WsmanSPNegoSchemeFactory.java
@@ -22,6 +22,7 @@
  */
 package com.xebialabs.overthere.winrm;
 
+import com.xebialabs.overthere.cifs.BaseCifsConnectionBuilder;
 import org.apache.http.auth.AuthScheme;
 import org.apache.http.impl.auth.SPNegoSchemeFactory;
 import org.apache.http.params.HttpParams;
@@ -37,23 +38,30 @@ class WsmanSPNegoSchemeFactory extends SPNegoSchemeFactory {
 
     private final int spnPort;
 
+    private final boolean useCanonicalHostname;
+
     public WsmanSPNegoSchemeFactory(boolean stripPort, final String spnServiceClass, final String spnHost, final int spnPort) {
-        super(stripPort);
+        this(stripPort, spnServiceClass, spnHost, spnPort, BaseCifsConnectionBuilder.WINRM_USE_CANONICAL_HOSTNAME_DEFAULT);
+    }
+
+    public WsmanSPNegoSchemeFactory(boolean stripPort, final String spnServiceClass, final String spnHost, final int spnPort, final boolean useCanonicalHostname) {
+        super(stripPort, useCanonicalHostname);
         this.spnServiceClass = spnServiceClass;
         this.spnHost = spnHost;
         this.spnPort = spnPort;
+        this.useCanonicalHostname = useCanonicalHostname;
     }
 
     @Override
     public AuthScheme newInstance(final HttpParams params) {
         logger.trace("WsmanSPNegoSchemeFactory.newInstance invoked for SPN {}/{} (spnPort = {}, stripPort = {})", new Object[] {spnServiceClass, spnHost, spnPort, isStripPort() });
-        return new WsmanSPNegoScheme(isStripPort(), spnServiceClass, spnHost, spnPort);
+        return new WsmanSPNegoScheme(isStripPort(), spnServiceClass, spnHost, spnPort, useCanonicalHostname);
     }
 
     @Override
     public AuthScheme create(final HttpContext context) {
         logger.trace("WsmanSPNegoSchemeFactory.create invoked for SPN {}/{} (spnPort = {}, stripPort = {})", new Object[] {spnServiceClass, spnHost, spnPort, isStripPort() });
-        return new WsmanSPNegoScheme(isStripPort(), spnServiceClass, spnHost, spnPort);
+        return new WsmanSPNegoScheme(isStripPort(), spnServiceClass, spnHost, spnPort, useCanonicalHostname);
     }
 
     private Logger logger = LoggerFactory.getLogger(WsmanSPNegoSchemeFactory.class);


### PR DESCRIPTION
… HttpClient framework since version 4.4.

 The default value is set to FALSE because this reflects the same behaviour as in the Overthere version 5.0.1.