### PR TITLE
DEPL-15483 Improve error handling on deletion

### DIFF
--- a/src/main/java/com/xebialabs/overthere/local/LocalFile.java
+++ b/src/main/java/com/xebialabs/overthere/local/LocalFile.java
@@ -205,7 +205,7 @@ public class LocalFile extends BaseOverthereFile<LocalConnection> implements Ser
                 @Override
                 public void close() throws IOException {
                     super.close();
-                    logger.debug("Closing file input stream for {}", this);
+                    logger.debug("Closed file input stream for {}", LocalFile.this);
                 }
             });
         } catch (FileNotFoundException exc) {
@@ -222,7 +222,7 @@ public class LocalFile extends BaseOverthereFile<LocalConnection> implements Ser
                 @Override
                 public void close() throws IOException {
                     super.close();
-                    logger.debug("Closing file output stream for {}", this);
+                    logger.debug("Closed file output stream for {}", LocalFile.this);
                 }
             });
         } catch (FileNotFoundException exc) {

--- a/src/main/java/com/xebialabs/overthere/local/LocalFile.java
+++ b/src/main/java/com/xebialabs/overthere/local/LocalFile.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -141,8 +142,10 @@ public class LocalFile extends BaseOverthereFile<LocalConnection> implements Ser
     public void delete() {
         logger.debug("Deleting {}", this);
 
-        if (!file.delete()) {
-            throw new RuntimeIOException("Cannot delete " + this);
+        try {
+            Files.delete(file.toPath());
+        } catch (IOException io) {
+            throw new RuntimeIOException("Cannot delete " + this, io);
         }
     }
 

--- a/src/main/java/com/xebialabs/overthere/spi/BaseOverthereFile.java
+++ b/src/main/java/com/xebialabs/overthere/spi/BaseOverthereFile.java
@@ -95,7 +95,7 @@ public abstract class BaseOverthereFile<C extends BaseOverthereConnection> imple
             if (allSucces) {
                 delete();
             } else {
-                logger.debug("Not deleting " + this + ", not all children are deleted.");
+                throw new RuntimeIOException("Cannot delete " + this + ", not all children are deleted.");
             }
         } else {
             delete();

--- a/src/main/java/com/xebialabs/overthere/spi/BaseOverthereFile.java
+++ b/src/main/java/com/xebialabs/overthere/spi/BaseOverthereFile.java
@@ -83,12 +83,23 @@ public abstract class BaseOverthereFile<C extends BaseOverthereConnection> imple
     @Override
     public void deleteRecursively() throws RuntimeIOException {
         if (isDirectory()) {
+            boolean allSucces = true;
             for (OverthereFile each : listFiles()) {
-                each.deleteRecursively();
+                try {
+                    each.deleteRecursively();
+                } catch (RuntimeIOException rio) {
+                    logger.warn("Unable to delete child "+ each + ". Continue...", rio);
+                    allSucces = false;
+                }
             }
+            if (allSucces) {
+                delete();
+            } else {
+                logger.debug("Not deleting " + this + ", not all children are deleted.");
+            }
+        } else {
+            delete();
         }
-
-        delete();
     }
 
     @Override


### PR DESCRIPTION
- Use `java.nio.file.Files.delete(path)` to get better error reporting.
- Continue deleting a file tree when 1 file cannot be deleted.
- Properly report on closing of streams.