### PR TITLE
Added SFTP_OpenSSHD for Windows connection type to overthere

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ To use the __SFTP_CYGWIN__ connection type, install [COPSSH](http://www.itefix.n
 
 To use the __SFTP_WINSSHD__ connection type, install [WinSSHD](http://www.bitvise.com/winsshd) on your Windows host. In the Easy WinSSHD Settings control panel, add the users as which you want to connect, check the _Login allowed_ checkbox and select _Allow full access_ in the _Virtual filesystem layout_ dropdown box. Alternatively you can check the _Allow login to any Windows account_ to allow access to all Windows accounts.<br/>__N.B.:__ Overthere will take care of the translation from Windows style paths, e.g. `C:\Program Files\IBM\WebSphere\AppServer`, to WinSSHD-style paths, e.g. `/C/Program Files/IBM/WebSphere/AppServer`, so that your code can use Windows style paths.
 
+<a name="ssh_host_setup_sftp_opensshd"></a>
+#### SFTP_OpenSSHD
+
+To use the __SFTP_OpenSSHD__ connection type, install [OpenSSHD](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse) on your Windows host and make sure the OpenSSH Server service is enabled.<br/>__N.B.:__ Overthere will take care of the translation from Windows style paths, e.g. `C:\Program Files\IBM\WebSphere\AppServer`, to OpenSSHD-style paths, e.g. `/C:/Program Files/IBM/WebSphere/AppServer`, so that your code can use Windows style paths.
+
 <a name="ssh_host_setup_sudo"></a>
 <a name="ssh_host_setup_interactive_sudo"></a>
 #### SUDO and INTERACTIVE_SUDO

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnectionBuilder.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnectionBuilder.java
@@ -506,6 +506,9 @@ public class SshConnectionBuilder implements OverthereConnectionBuilder {
             case SFTP_WINSSHD:
                 connection = new SshSftpWinSshdConnection(type, options, mapper);
                 break;
+            case SFTP_OpenSSHD:
+                connection = new SshSftpOpenSshdConnection(type, options, mapper);
+                break;
             case SCP:
                 connection = new SshScpConnection(type, options, mapper);
                 break;

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnectionType.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnectionType.java
@@ -43,6 +43,11 @@ public enum SshConnectionType {
     SFTP_WINSSHD,
 
     /**
+     * An SSH connection that uses SFTP to transfer files, to a Windows host running OpenSSHD.
+     */
+    SFTP_OpenSSHD,
+
+    /**
      * An SSH connection that uses SCP to transfer files, to a Unix host.
      */
     SCP,

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpOpenSshdConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpOpenSshdConnection.java
@@ -63,8 +63,7 @@ class SshSftpOpenSshdConnection extends SshSftpConnection {
         } else {
             throw new RuntimeIOException(format("Cannot translate Windows path [%s] to a OpenSSHD path because it is not a Windows path", path));
         }
-        // logger.trace("Translated Windows path [{}] to OpenSSHD path [{}]", path, translatedPath);
-        logger.info("Translated Windows path [{}] to OpenSSHD path [{}]", path, translatedPath);
+        logger.trace("Translated Windows path [{}] to OpenSSHD path [{}]", path, translatedPath);
         return translatedPath;
     }
 

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpOpenSshdConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpOpenSshdConnection.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2008-2016, XebiaLabs B.V., All rights reserved.
+ *
+ *
+ * Overthere is licensed under the terms of the GPLv2
+ * <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most XebiaLabs Libraries.
+ * There are special exceptions to the terms and conditions of the GPLv2 as it is applied to
+ * this software, see the FLOSS License Exception
+ * <http://github.com/xebialabs/overthere/blob/master/LICENSE>.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation; version 2
+ * of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
+ * Floor, Boston, MA 02110-1301  USA
+ */
+package com.xebialabs.overthere.ssh;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.xebialabs.overthere.ConnectionOptions;
+import com.xebialabs.overthere.RuntimeIOException;
+import com.xebialabs.overthere.spi.AddressPortMapper;
+
+import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
+import static com.xebialabs.overthere.OperatingSystemFamily.WINDOWS;
+import static com.xebialabs.overthere.ssh.SshConnectionBuilder.SSH_PROTOCOL;
+import static java.lang.Character.toUpperCase;
+import static java.lang.String.format;
+
+/**
+ * A connection to a Windows host running OpenSSHD.
+ */
+class SshSftpOpenSshdConnection extends SshSftpConnection {
+
+    public SshSftpOpenSshdConnection(String type, ConnectionOptions options, AddressPortMapper mapper) {
+           
+        super(type, options, mapper);
+        checkArgument(os == WINDOWS, "Cannot create a %s connection to a host that is not running Windows", protocolAndConnectionType);
+    }
+
+    @Override
+    protected void connect() {
+        // In OpenSSHD we have to wait for the server ident before sending our ident.
+        // config.setWaitForServerIdentBeforeSendingClientIdent(true);
+        super.connect();
+    }
+
+    @Override
+    protected String pathToSftpPath(String path) {
+        String translatedPath;
+        if (path.length() >= 2 && path.charAt(1) == ':') {
+            char driveLetter = toUpperCase(path.charAt(0));
+            String pathInDrive = path.substring(2).replace('\\', '/');
+            translatedPath = "/" + driveLetter + ":" + pathInDrive;
+        } else {
+            throw new RuntimeIOException(format("Cannot translate Windows path [%s] to a OpenSSHD path because it is not a Windows path", path));
+        }
+        // logger.trace("Translated Windows path [{}] to OpenSSHD path [{}]", path, translatedPath);
+        logger.info("Translated Windows path [{}] to OpenSSHD path [{}]", path, translatedPath);
+        return translatedPath;
+    }
+
+    private static Logger logger = LoggerFactory.getLogger(SshSftpOpenSshdConnection.class);
+
+}


### PR DESCRIPTION
Windows Server 2019 and Windows 10 1809 comes nowadays with a PowerShell implementation of OpenSSHD. This pullrequest enables the use of this daemon to the overthere library.
The connection type is almost the same as the WinSSHD implementation except for the path conversion. Where WinSSHD translates a Windows path `c:\temp` to `/C/temp`, OpenSSHD translates this to `/C:/temp`.

