### PR TITLE
Minor Code Cleanup

### DIFF
--- a/src/main/java/com/xebialabs/overthere/CmdLine.java
+++ b/src/main/java/com/xebialabs/overthere/CmdLine.java
@@ -27,13 +27,10 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.xebialabs.overthere.CmdLineArgument.*;
+import static com.xebialabs.overthere.OperatingSystemFamily.UNIX;
 import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.util.OverthereUtils.checkState;
-import static com.xebialabs.overthere.CmdLineArgument.arg;
-import static com.xebialabs.overthere.CmdLineArgument.nested;
-import static com.xebialabs.overthere.CmdLineArgument.password;
-import static com.xebialabs.overthere.CmdLineArgument.raw;
-import static com.xebialabs.overthere.OperatingSystemFamily.UNIX;
 import static java.util.Collections.unmodifiableList;
 
 /**
@@ -42,7 +39,7 @@ import static java.util.Collections.unmodifiableList;
 @SuppressWarnings("serial")
 public class CmdLine implements Serializable {
 
-    List<CmdLineArgument> arguments = new ArrayList<CmdLineArgument>();
+    List<CmdLineArgument> arguments = new ArrayList<>();
 
     /**
      * Adds {@link CmdLineArgument#arg(String) a regular argument} to the command line.

--- a/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
+++ b/src/main/java/com/xebialabs/overthere/ConnectionOptions.java
@@ -200,7 +200,7 @@ public class ConnectionOptions {
      * Creates an empty options object.
      */
     public ConnectionOptions() {
-        options = new HashMap<String, Object>();
+        options = new HashMap<>();
     }
 
     /**

--- a/src/main/java/com/xebialabs/overthere/OverthereConnector.java
+++ b/src/main/java/com/xebialabs/overthere/OverthereConnector.java
@@ -23,8 +23,8 @@ import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
 public class OverthereConnector {
     private static final Logger logger = LoggerFactory.getLogger(OverthereConnector.class);
 
-    final AtomicReference<Map<String, Class<? extends OverthereConnectionBuilder>>> protocols = new AtomicReference<Map<String, Class<? extends OverthereConnectionBuilder>>>(
-            new HashMap<String, Class<? extends OverthereConnectionBuilder>>());
+    final AtomicReference<Map<String, Class<? extends OverthereConnectionBuilder>>> protocols = new AtomicReference<>(
+            new HashMap<>());
 
 
     public void registerProtocol(Class<? extends OverthereConnectionBuilder> builderClass) {

--- a/src/main/java/com/xebialabs/overthere/cifs/CifsFile.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/CifsFile.java
@@ -22,22 +22,20 @@
  */
 package com.xebialabs.overthere.cifs;
 
+import com.xebialabs.overthere.OverthereFile;
+import com.xebialabs.overthere.RuntimeIOException;
+import com.xebialabs.overthere.spi.BaseOverthereFile;
+import jcifs.smb.SmbException;
+import jcifs.smb.SmbFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
-
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.xebialabs.overthere.OverthereFile;
-import com.xebialabs.overthere.RuntimeIOException;
-import com.xebialabs.overthere.spi.BaseOverthereFile;
 
 import static java.lang.String.format;
 
@@ -184,14 +182,12 @@ class CifsFile extends BaseOverthereFile<CifsConnection> {
 
         try {
             upgradeToDirectorySmbFile();
-            List<OverthereFile> files = new ArrayList<OverthereFile>();
+            List<OverthereFile> files = new ArrayList<>();
             for (String name : smbFile.list()) {
                 files.add(getFile(name));
             }
             return files;
-        } catch (MalformedURLException exc) {
-            throw new RuntimeIOException(format("Cannot list directory %s: %s", smbFile.getUncPath(), exc.toString()), exc);
-        } catch (SmbException exc) {
+        } catch (MalformedURLException | SmbException exc) {
             throw new RuntimeIOException(format("Cannot list directory %s: %s", smbFile.getUncPath(), exc.toString()), exc);
         }
     }
@@ -253,9 +249,7 @@ class CifsFile extends BaseOverthereFile<CifsConnection> {
             }
             smbFile.delete();
             refreshSmbFile();
-        } catch (MalformedURLException exc) {
-            throw new RuntimeIOException(format("Cannot delete %s: %s", smbFile.getUncPath(), exc.toString()), exc);
-        } catch (SmbException exc) {
+        } catch (MalformedURLException | SmbException exc) {
             throw new RuntimeIOException(format("Cannot delete %s: %s", smbFile.getUncPath(), exc.toString()), exc);
         }
     }
@@ -270,9 +264,7 @@ class CifsFile extends BaseOverthereFile<CifsConnection> {
             }
             smbFile.delete();
             refreshSmbFile();
-        } catch (MalformedURLException exc) {
-            throw new RuntimeIOException(format("Cannot delete %s recursively: %s", smbFile.getUncPath(), exc.toString()), exc);
-        } catch (SmbException exc) {
+        } catch (MalformedURLException | SmbException exc) {
             throw new RuntimeIOException(format("Cannot delete %s recursively: %s", smbFile.getUncPath(), exc.toString()), exc);
         }
     }

--- a/src/main/java/com/xebialabs/overthere/cifs/PathEncoder.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/PathEncoder.java
@@ -22,13 +22,13 @@
  */
 package com.xebialabs.overthere.cifs;
 
+import com.xebialabs.overthere.RuntimeIOException;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import com.xebialabs.overthere.RuntimeIOException;
 
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.CIFS_PORT_DEFAULT;
 import static java.lang.String.format;
@@ -87,10 +87,8 @@ class PathEncoder {
         // Java-style Windows paths.
         hostPath = hostPath.replace('/', WINDOWS_SEPARATOR);
 
-        if (hostPath.length() >= 3) {
-            if (hostPath.charAt(2) != WINDOWS_SEPARATOR) {
-                throw new IllegalArgumentException(format("Host path '%s' does not have a backslash (\\) as its third character", hostPath));
-            }
+        if (hostPath.length() >= 3 && hostPath.charAt(2) != WINDOWS_SEPARATOR) {
+            throw new IllegalArgumentException(format("Host path '%s' does not have a backslash (\\) as its third character", hostPath));
         }
 
         StringBuilder smbUrl = new StringBuilder(smbUrlPrefix);

--- a/src/main/java/com/xebialabs/overthere/cifs/PathMapper.java
+++ b/src/main/java/com/xebialabs/overthere/cifs/PathMapper.java
@@ -40,13 +40,8 @@ public class PathMapper {
 
     public PathMapper(final Map<String, String> mappings) {
         // longest first, so reverse lexicographical order
-        SortedMap<String, String> sharesForPath = new TreeMap<String, String>(new Comparator<String>() {
-            @Override
-            public int compare(String o1, String o2) {
-                return o2.compareTo(o1);
-            }
-        });
-        Map<String, String> pathsForShare = new HashMap<String, String>();
+        SortedMap<String, String> sharesForPath = new TreeMap<>((o1, o2) -> o2.compareTo(o1));
+        Map<String, String> pathsForShare = new HashMap<>();
 
         for (Entry<String, String> mapping : mappings.entrySet()) {
             String pathPrefixToMatch = mapping.getKey();

--- a/src/main/java/com/xebialabs/overthere/gcp/BouncycastleGenerateSshKey.java
+++ b/src/main/java/com/xebialabs/overthere/gcp/BouncycastleGenerateSshKey.java
@@ -39,10 +39,8 @@ class BouncycastleGenerateSshKey implements GenerateSshKey {
                     PrimeCertaintyCalculator.getDefaultCertainty(keySize)));
             AsymmetricCipherKeyPair asymmetricCipherKeyPair = rsaKeyPairGenerator.generateKeyPair();
             PrivateKeyInfo pkInfo = PrivateKeyInfoFactory.createPrivateKeyInfo(asymmetricCipherKeyPair.getPrivate());
-            String privateKey2 = new String(Base64.encode(pkInfo.getEncoded(ASN1Encoding.DER)));
 
             SubjectPublicKeyInfo info = SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(asymmetricCipherKeyPair.getPublic());
-            String publicKey2 = new String(Base64.encode(info.getEncoded(ASN1Encoding.DER)));
 
             return new SshKeyPair(username, privateKey, publicKey, "");
         } catch (Exception e) {

--- a/src/main/java/com/xebialabs/overthere/gcp/GcpSshConnectionBuilder.java
+++ b/src/main/java/com/xebialabs/overthere/gcp/GcpSshConnectionBuilder.java
@@ -1,8 +1,5 @@
 package com.xebialabs.overthere.gcp;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.xebialabs.overthere.ConnectionOptions;
 import com.xebialabs.overthere.OverthereConnection;
 import com.xebialabs.overthere.RuntimeIOException;
@@ -10,8 +7,9 @@ import com.xebialabs.overthere.spi.AddressPortMapper;
 import com.xebialabs.overthere.spi.Protocol;
 import com.xebialabs.overthere.ssh.GcpSshConnectionConfigurer;
 import com.xebialabs.overthere.ssh.SshConnectionBuilder;
-
 import net.schmizz.sshj.userauth.UserAuthException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.xebialabs.overthere.ConnectionOptions.USERNAME;
 
@@ -150,7 +148,7 @@ public class GcpSshConnectionBuilder extends SshConnectionBuilder {
             try {
                 return tryToConnect();
             } catch (RuntimeIOException e) {
-                if (e.getCause() != null && e.getCause() instanceof UserAuthException) {
+                if (e.getCause() instanceof UserAuthException) {
                     try {
                         Thread.sleep(retryPeriodMillis);
                     } catch (InterruptedException interruptedException) {

--- a/src/main/java/com/xebialabs/overthere/gcp/credentials/GcpCredentialFactory.java
+++ b/src/main/java/com/xebialabs/overthere/gcp/credentials/GcpCredentialFactory.java
@@ -1,8 +1,9 @@
 package com.xebialabs.overthere.gcp.credentials;
 
-import java.util.Collections;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
+
+import java.util.Collections;
 
 /**
  * Abstract factory that base for implementation of credential factory.
@@ -19,10 +20,10 @@ public abstract class GcpCredentialFactory {
     public ProjectCredentials withScope(ProjectCredentials projectCredentials) {
         Credentials credentials = projectCredentials.getCredentials();
         if (credentials instanceof GoogleCredentials) {
-            GoogleCredentials GcpCredentialFactory = (GoogleCredentials) credentials;
-            if (GcpCredentialFactory.createScopedRequired()) {
+            GoogleCredentials gcpCredentialFactory = (GoogleCredentials) credentials;
+            if (gcpCredentialFactory.createScopedRequired()) {
                 return new ProjectCredentials(
-                        GcpCredentialFactory.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform")),
+                        gcpCredentialFactory.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform")),
                         projectCredentials.getProjectId(),
                         projectCredentials.getClientEmail());
             }

--- a/src/main/java/com/xebialabs/overthere/local/LocalFile.java
+++ b/src/main/java/com/xebialabs/overthere/local/LocalFile.java
@@ -61,10 +61,9 @@ public class LocalFile extends BaseOverthereFile<LocalConnection> implements Ser
     private static LocalConnection createConnection() {
         // Creating LocalConnection directly instead of through Overthere.getConnection() to prevent log messages from
         // appearing
-        LocalConnection localConnectionThatWillNeverBeDisconnected = new LocalConnection(LOCAL_PROTOCOL, new ConnectionOptions());
         // FIXME: Creating a LocalConnection on the fly does not honour the original TEMPORARY_DIRECTORY_PATH (tmp)
         // setting
-        return localConnectionThatWillNeverBeDisconnected;
+        return new LocalConnection(LOCAL_PROTOCOL, new ConnectionOptions());
     }
 
     public File getFile() {
@@ -171,7 +170,7 @@ public class LocalFile extends BaseOverthereFile<LocalConnection> implements Ser
     public List<OverthereFile> listFiles() {
         logger.debug("Listing directory {}", this);
 
-        List<OverthereFile> list = new ArrayList<OverthereFile>();
+        List<OverthereFile> list = new ArrayList<>();
         for (File each : file.listFiles()) {
             list.add(new LocalFile(connection, each));
         }

--- a/src/main/java/com/xebialabs/overthere/smb/SmbFile.java
+++ b/src/main/java/com/xebialabs/overthere/smb/SmbFile.java
@@ -29,8 +29,7 @@ import com.hierynomus.msfscc.fileinformation.FileIdBothDirectoryInformation;
 import com.hierynomus.mssmb2.SMB2CreateDisposition;
 import com.hierynomus.mssmb2.SMB2ShareAccess;
 import com.hierynomus.mssmb2.SMBApiException;
-import com.hierynomus.protocol.commons.EnumWithValue;
-import com.hierynomus.protocol.transport.TransportException;
+import com.hierynomus.protocol.commons.EnumWithValue.EnumUtils;
 import com.hierynomus.smbj.share.DiskEntry;
 import com.hierynomus.smbj.share.DiskShare;
 import com.hierynomus.smbj.share.File;
@@ -43,11 +42,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static java.lang.String.format;
 
@@ -114,7 +109,7 @@ public class SmbFile extends BaseOverthereFile<SmbConnection> {
     private boolean checkAccess(Set<AccessMask> requestAccesSet, AccessMask searchAccessMask) {
         try {
             int accessFlags = getAccessMask(requestAccesSet);
-            return EnumWithValue.EnumUtils.isSet(accessFlags, searchAccessMask);
+            return EnumUtils.isSet(accessFlags, searchAccessMask);
         } catch(SMBApiException e) {
             logger.warn("Acces denied to {} : {}", getPath(), e.getMessage());
             if (e.getStatus() == NtStatus.STATUS_ACCESS_DENIED) {
@@ -269,7 +264,7 @@ public class SmbFile extends BaseOverthereFile<SmbConnection> {
         String sharePath = getPathOnShare();
         logger.debug("Listing directory {}", sharePath);
         try {
-            List<OverthereFile> files = new ArrayList<OverthereFile>();
+            List<OverthereFile> files = new ArrayList<>();
             for (FileIdBothDirectoryInformation info : getShare().list(sharePath)) {
                 if (!info.getFileName().equals(".") && !info.getFileName().equals("..")) {
                     files.add(getFile(info.getFileName()));
@@ -387,7 +382,7 @@ public class SmbFile extends BaseOverthereFile<SmbConnection> {
 
     private boolean checkAttributes(FileAttributes mask) {
         long attrMask = getShare().getFileInformation(getPathOnShare()).getBasicInformation().getFileAttributes();
-        return FileAttributes.EnumUtils.isSet(attrMask, mask);
+        return EnumUtils.isSet(attrMask, mask);
     }
 
     private SmbFile getFileForAbsolutePath(String path) {

--- a/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
+++ b/src/main/java/com/xebialabs/overthere/spi/BaseOverthereConnection.java
@@ -22,6 +22,11 @@
  */
 package com.xebialabs.overthere.spi;
 
+import com.xebialabs.overthere.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.SimpleDateFormat;
@@ -30,26 +35,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.xebialabs.overthere.CmdLine;
-import com.xebialabs.overthere.ConnectionOptions;
-import com.xebialabs.overthere.OperatingSystemFamily;
-import com.xebialabs.overthere.OverthereConnection;
-import com.xebialabs.overthere.OverthereExecutionOutputHandler;
-import com.xebialabs.overthere.OverthereFile;
-import com.xebialabs.overthere.OverthereProcess;
-import com.xebialabs.overthere.OverthereProcessOutputHandler;
-import com.xebialabs.overthere.RuntimeIOException;
-import org.slf4j.MDC;
-
-import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.ConnectionOptions.*;
 import static com.xebialabs.overthere.util.ConsoleOverthereExecutionOutputHandler.syserrHandler;
 import static com.xebialabs.overthere.util.ConsoleOverthereExecutionOutputHandler.sysoutHandler;
 import static com.xebialabs.overthere.util.OverthereProcessOutputHandlerWrapper.wrapStderr;
 import static com.xebialabs.overthere.util.OverthereProcessOutputHandlerWrapper.wrapStdout;
+import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
 import static java.lang.String.format;
 
@@ -73,7 +65,7 @@ public abstract class BaseOverthereConnection implements OverthereConnection {
     protected final boolean deleteTemporaryDirectoryOnDisconnect;
     protected final int temporaryFileCreationRetries;
     protected final String temporaryFileHolderDirectoryNamePrefix;
-    protected final List<OverthereFile> temporaryFileHolderDirectories = new ArrayList<OverthereFile>();
+    protected final List<OverthereFile> temporaryFileHolderDirectories = new ArrayList<>();
     protected final int streamBufferSize;
     protected int temporaryFileHolderDirectoryNameSuffix = 0;
     protected OverthereFile workingDirectory;

--- a/src/main/java/com/xebialabs/overthere/ssh/OverthereFileLocalSourceFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/OverthereFileLocalSourceFile.java
@@ -74,7 +74,7 @@ class OverthereFileLocalSourceFile implements LocalSourceFile {
 
     @Override
     public Iterable<? extends LocalSourceFile> getChildren(LocalFileFilter filter) throws IOException {
-        List<LocalSourceFile> files = new ArrayList<LocalSourceFile>();
+        List<LocalSourceFile> files = new ArrayList<>();
         for (OverthereFile each : f.listFiles()) {
             files.add(new OverthereFileLocalSourceFile(each));
         }

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
@@ -32,11 +32,9 @@ import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.Factory;
 import net.schmizz.sshj.common.SSHException;
 import net.schmizz.sshj.connection.ConnectionException;
-import net.schmizz.sshj.connection.channel.direct.PTYMode;
 import net.schmizz.sshj.connection.channel.direct.Session;
 import net.schmizz.sshj.transport.TransportException;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
-import net.schmizz.sshj.userauth.UserAuthException;
 import net.schmizz.sshj.userauth.keyprovider.FileKeyProvider;
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
 import net.schmizz.sshj.userauth.keyprovider.PKCS5KeyFile;
@@ -116,12 +114,7 @@ abstract class SshConnection extends BaseOverthereConnection {
         config.setFileKeyProviderFactories(current);
     }
 
-    protected Factory<SSHClient> sshClientFactory = new Factory<SSHClient>() {
-        @Override
-        public SSHClient create() {
-            return new SSHClient(config);
-        }
-    };
+    protected Factory<SSHClient> sshClientFactory = () -> new SSHClient(config);
 
     public SshConnection(final String protocol, final ConnectionOptions options, final AddressPortMapper mapper) {
         super(protocol, options, mapper, true);
@@ -332,12 +325,12 @@ abstract class SshConnection extends BaseOverthereConnection {
                 checkArgument(matcher.matches(), "Value for allocatePty [%s] does not match pattern \"" + PTY_PATTERN + "\"", allocatePty);
 
                 String term = matcher.group(1);
-                int cols = Integer.valueOf(matcher.group(2));
-                int rows = Integer.valueOf(matcher.group(3));
-                int width = Integer.valueOf(matcher.group(4));
-                int height = Integer.valueOf(matcher.group(5));
-                logger.debug("Allocating PTY {}:{}:{}:{}:{}", new Object[]{term, cols, rows, width, height});
-                session.allocatePTY(term, cols, rows, width, height, Collections.<PTYMode, Integer>emptyMap());
+                int cols = Integer.parseInt(matcher.group(2));
+                int rows = Integer.parseInt(matcher.group(3));
+                int width = Integer.parseInt(matcher.group(4));
+                int height = Integer.parseInt(matcher.group(5));
+                logger.debug("Allocating PTY {}:{}:{}:{}:{}", term, cols, rows, width, height);
+                session.allocatePTY(term, cols, rows, width, height, Collections.emptyMap());
             } else if (allocateDefaultPty) {
                 logger.debug("Allocating default PTY");
                 session.allocateDefaultPTY();

--- a/src/main/java/com/xebialabs/overthere/ssh/SshFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshFile.java
@@ -134,7 +134,7 @@ abstract class SshFile<C extends SshConnection> extends BaseOverthereFile<C> {
 
     static List<String> splitPath(String path, OperatingSystemFamily os) {
         Pattern s = os == WINDOWS ? WINDOWS_PATH_SPLITTER : UNIX_PATH_SPLITTER;
-        List<String> l = new ArrayList<String>();
+        List<String> l = new ArrayList<>();
         for (String p : s.split(path)) {
             if (p.isEmpty()) continue;
             l.add(p);

--- a/src/main/java/com/xebialabs/overthere/ssh/SshProcess.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshProcess.java
@@ -22,21 +22,19 @@
  */
 package com.xebialabs.overthere.ssh;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.xebialabs.overthere.CmdLine;
 import com.xebialabs.overthere.OperatingSystemFamily;
 import com.xebialabs.overthere.OverthereProcess;
 import com.xebialabs.overthere.RuntimeIOException;
-
 import net.schmizz.sshj.common.SSHException;
 import net.schmizz.sshj.connection.ConnectionException;
 import net.schmizz.sshj.connection.channel.direct.Session;
-import net.schmizz.sshj.connection.channel.direct.Signal;
 import net.schmizz.sshj.transport.TransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
 import static java.lang.String.format;
@@ -86,7 +84,7 @@ class SshProcess implements OverthereProcess {
         try {
             command.join();
             Integer exitStatus = command.getExitStatus();
-            logger.info("Command [{}] on {} returned exit code {}", new Object[]{obfuscatedCommandLine, connection, exitStatus});
+            logger.info("Command [{}] on {} returned exit code {}", obfuscatedCommandLine, connection, exitStatus);
             closeSession();
             if (exitStatus == null) {
                 logger.warn("Command [{}] on {} could not be started. Returning exit code -1", obfuscatedCommandLine, connection);

--- a/src/main/java/com/xebialabs/overthere/ssh/SshScpFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshScpFile.java
@@ -134,9 +134,9 @@ class SshScpFile extends SshFile<SshScpConnection> {
             results.exists = false;
         }
 
-        logger.debug("Listed file {}: exists={}, isDirectory={}, length={}, canRead={}, canWrite={}, canExecute={}", new Object[]{this, results.exists,
+        logger.debug("Listed file {}: exists={}, isDirectory={}, length={}, canRead={}, canWrite={}, canExecute={}", this, results.exists,
                 results.isDirectory, results.length
-                , results.canRead, results.canWrite, results.canExecute});
+                , results.canRead, results.canWrite, results.canExecute);
 
         return results;
     }
@@ -265,7 +265,7 @@ class SshScpFile extends SshFile<SshScpConnection> {
             throw new RuntimeIOException("Cannot list directory " + this + ": " + capturedStderr.getOutput() + " (errno=" + errno + ")");
         }
 
-        List<OverthereFile> files = new ArrayList<OverthereFile>();
+        List<OverthereFile> files = new ArrayList<>();
         for (String lsLine : capturedStdout.getOutputLines()) {
             // Filter out the '.' and '..'
             if (!(".".equals(lsLine) || "..".equals(lsLine))) {

--- a/src/main/java/com/xebialabs/overthere/ssh/SshSftpFile.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshSftpFile.java
@@ -121,7 +121,7 @@ class SshSftpFile extends SshFile<SshSftpConnection> {
             List<RemoteResourceInfo> ls = connection.getSharedSftpClient().ls(getSftpPath());
 
             // copy files to list, skipping . and ..
-            List<OverthereFile> files = new ArrayList<OverthereFile>();
+            List<OverthereFile> files = new ArrayList<>();
             for (RemoteResourceInfo l : ls) {
                 String filename = l.getName();
                 if (filename.equals(".") || filename.equals("..")) {

--- a/src/main/java/com/xebialabs/overthere/ssh/SshTunnelConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshTunnelConnection.java
@@ -22,6 +22,17 @@
  */
 package com.xebialabs.overthere.ssh;
 
+import com.xebialabs.overthere.*;
+import com.xebialabs.overthere.spi.AddressPortMapper;
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.connection.ConnectionException;
+import net.schmizz.sshj.connection.channel.direct.LocalPortForwarder;
+import net.schmizz.sshj.connection.channel.direct.Session;
+import net.schmizz.sshj.transport.TransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.SocketFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -35,28 +46,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.xebialabs.overthere.CmdLine;
-import com.xebialabs.overthere.ConnectionOptions;
-import com.xebialabs.overthere.OverthereExecutionOutputHandler;
-import com.xebialabs.overthere.OverthereFile;
-import com.xebialabs.overthere.OverthereProcess;
-import com.xebialabs.overthere.RuntimeIOException;
-import com.xebialabs.overthere.spi.AddressPortMapper;
-
-import net.schmizz.sshj.SSHClient;
-import net.schmizz.sshj.connection.ConnectionException;
-import net.schmizz.sshj.connection.channel.direct.LocalPortForwarder;
-import net.schmizz.sshj.connection.channel.direct.Session;
-import net.schmizz.sshj.transport.TransportException;
-
-import javax.net.SocketFactory;
-
-import static com.xebialabs.overthere.util.OverthereUtils.checkState;
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.PORT_ALLOCATION_RANGE_START;
 import static com.xebialabs.overthere.ssh.SshConnectionBuilder.PORT_ALLOCATION_RANGE_START_DEFAULT;
+import static com.xebialabs.overthere.util.OverthereUtils.checkState;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
 import static java.lang.String.format;
 import static java.net.InetSocketAddress.createUnresolved;
@@ -66,13 +58,13 @@ import static java.net.InetSocketAddress.createUnresolved;
  */
 public class SshTunnelConnection extends SshConnection implements AddressPortMapper {
 
-    private static final AtomicReference<TunnelPortManager> PORT_MANAGER = new AtomicReference<TunnelPortManager>(new TunnelPortManager());
+    private static final AtomicReference<TunnelPortManager> PORT_MANAGER = new AtomicReference<>(new TunnelPortManager());
 
     private static final int MAX_PORT = 65535;
 
-    private Map<InetSocketAddress, InetSocketAddress> localPortForwards = new HashMap<InetSocketAddress, InetSocketAddress>();
+    private Map<InetSocketAddress, InetSocketAddress> localPortForwards = new HashMap<>();
 
-    private List<PortForwarder> portForwarders = new ArrayList<PortForwarder>();
+    private List<PortForwarder> portForwarders = new ArrayList<>();
 
     private int startPortRange;
 

--- a/src/main/java/com/xebialabs/overthere/telnet/TelnetConnection.java
+++ b/src/main/java/com/xebialabs/overthere/telnet/TelnetConnection.java
@@ -24,8 +24,8 @@ package com.xebialabs.overthere.telnet;
 
 import com.xebialabs.overthere.*;
 import com.xebialabs.overthere.cifs.CifsConnectionType;
-import com.xebialabs.overthere.spi.ProcessConnection;
 import com.xebialabs.overthere.spi.AddressPortMapper;
+import com.xebialabs.overthere.spi.ProcessConnection;
 import org.apache.commons.net.telnet.InvalidTelnetOptionException;
 import org.apache.commons.net.telnet.TelnetClient;
 import org.apache.commons.net.telnet.WindowSizeOptionHandler;
@@ -38,9 +38,7 @@ import java.net.InetSocketAddress;
 import static com.xebialabs.overthere.ConnectionOptions.*;
 import static com.xebialabs.overthere.cifs.ConnectionValidator.checkIsWindowsHost;
 import static com.xebialabs.overthere.cifs.ConnectionValidator.checkNotNewStyleWindowsDomain;
-import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
-import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
-import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
+import static com.xebialabs.overthere.util.OverthereUtils.*;
 import static java.lang.String.format;
 import static java.net.InetSocketAddress.createUnresolved;
 /**
@@ -241,9 +239,7 @@ public class TelnetConnection implements ProcessConnection {
                     }
                 }
             };
-        } catch (InvalidTelnetOptionException exc) {
-            throw new RuntimeIOException("Cannot execute command " + cmd + " at telnet://" + username + "@" + address, exc);
-        } catch (IOException exc) {
+        } catch (InvalidTelnetOptionException | IOException exc) {
             throw new RuntimeIOException("Cannot execute command " + cmd + " at telnet://" + username + "@" + address, exc);
         }
     }

--- a/src/main/java/com/xebialabs/overthere/util/ByteArrayConnection.java
+++ b/src/main/java/com/xebialabs/overthere/util/ByteArrayConnection.java
@@ -28,6 +28,8 @@ import com.xebialabs.overthere.spi.BaseOverthereConnection;
 
 class ByteArrayConnection extends BaseOverthereConnection {
 
+    public static final String MESSAGE = "ByteArrayConnection has no functionality. Use only the created ByteArrayFile.";
+
     protected ByteArrayConnection(String protocol, ConnectionOptions options) {
         super(protocol, options, new DefaultAddressPortMapper(), false);
     }
@@ -39,17 +41,17 @@ class ByteArrayConnection extends BaseOverthereConnection {
 
     @Override
     public OverthereFile getFile(String hostPath) {
-        throw new UnsupportedOperationException("ByteArrayConnection has no functionality. Use only the created ByteArrayFile.");
+        throw new UnsupportedOperationException(MESSAGE);
     }
 
     @Override
     public OverthereFile getFile(OverthereFile parent, String child) {
-        throw new UnsupportedOperationException("ByteArrayConnection has no functionality. Use only the created ByteArrayFile.");
+        throw new UnsupportedOperationException(MESSAGE);
     }
 
     @Override
     protected OverthereFile getFileForTempFile(OverthereFile parent, String name) {
-        throw new UnsupportedOperationException("ByteArrayConnection has no functionality. Use only the created ByteArrayFile.");
+        throw new UnsupportedOperationException(MESSAGE);
     }
 
     @Override

--- a/src/main/java/com/xebialabs/overthere/util/ByteArrayFile.java
+++ b/src/main/java/com/xebialabs/overthere/util/ByteArrayFile.java
@@ -22,16 +22,16 @@
  */
 package com.xebialabs.overthere.util;
 
+import com.xebialabs.overthere.ConnectionOptions;
+import com.xebialabs.overthere.OperatingSystemFamily;
+import com.xebialabs.overthere.OverthereFile;
+import com.xebialabs.overthere.spi.BaseOverthereFile;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.xebialabs.overthere.ConnectionOptions;
-import com.xebialabs.overthere.OperatingSystemFamily;
-import com.xebialabs.overthere.OverthereFile;
-import com.xebialabs.overthere.spi.BaseOverthereFile;
 
 import static com.xebialabs.overthere.ConnectionOptions.OPERATING_SYSTEM;
 import static com.xebialabs.overthere.ConnectionOptions.TEMPORARY_DIRECTORY_PATH;
@@ -152,7 +152,7 @@ public class ByteArrayFile extends BaseOverthereFile<ByteArrayConnection> {
 
     @Override
     public List<OverthereFile> listFiles() {
-        return new ArrayList<OverthereFile>();
+        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/com/xebialabs/overthere/util/CapturingOverthereProcessOutputHandler.java
+++ b/src/main/java/com/xebialabs/overthere/util/CapturingOverthereProcessOutputHandler.java
@@ -38,11 +38,11 @@ import static java.util.Collections.unmodifiableList;
 @Deprecated
 public final class CapturingOverthereProcessOutputHandler implements OverthereProcessOutputHandler {
 
-    private final List<String> outputLines = new ArrayList<String>();
+    private final List<String> outputLines = new ArrayList<>();
 
-    private final List<String> errorLines = new ArrayList<String>();
+    private final List<String> errorLines = new ArrayList<>();
 
-    private final List<String> allLines = new ArrayList<String>();
+    private final List<String> allLines = new ArrayList<>();
 
     private CapturingOverthereProcessOutputHandler() {
     }

--- a/src/main/java/com/xebialabs/overthere/util/LoggingOverthereExecutionOutputHandler.java
+++ b/src/main/java/com/xebialabs/overthere/util/LoggingOverthereExecutionOutputHandler.java
@@ -22,9 +22,8 @@
  */
 package com.xebialabs.overthere.util;
 
-import org.slf4j.Logger;
-
 import com.xebialabs.overthere.OverthereExecutionOutputHandler;
+import org.slf4j.Logger;
 
 /**
  * Implementation of the {@link com.xebialabs.overthere.OverthereExecutionOutputHandler} interface that sends the output to the specified logger.
@@ -35,7 +34,7 @@ public class LoggingOverthereExecutionOutputHandler implements OverthereExecutio
     /**
      * Enum that controls to which level the message gets sent.
      */
-    private static enum LogLevel {
+    private enum LogLevel {
         INFO {
             void log(Logger logger, String message) {
                 logger.info(message);

--- a/src/main/java/com/xebialabs/overthere/util/OverthereFileCopier.java
+++ b/src/main/java/com/xebialabs/overthere/util/OverthereFileCopier.java
@@ -24,15 +24,10 @@ package com.xebialabs.overthere.util;
 
 import com.xebialabs.overthere.OverthereFile;
 import com.xebialabs.overthere.RuntimeIOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Stack;
 
-import static com.xebialabs.overthere.util.OverthereFileDirectoryWalker.ROOT;
 import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
 import static com.xebialabs.overthere.util.OverthereUtils.write;
 
@@ -46,9 +41,6 @@ public final class OverthereFileCopier extends OverthereFileTransmitter {
 
     private static final String SOURCE = "Source";
     private static final String DESTINATION = "Destination";
-
-    private Stack<OverthereFile> dstDirStack = new Stack<OverthereFile>();
-    private OverthereFile srcDir;
 
     private OverthereFileCopier() {
     }

--- a/src/main/java/com/xebialabs/overthere/util/OverthereFileTransmitter.java
+++ b/src/main/java/com/xebialabs/overthere/util/OverthereFileTransmitter.java
@@ -12,7 +12,7 @@ public abstract class OverthereFileTransmitter extends OverthereFileDirectoryWal
     private static final String SOURCE = "Source";
     private static final String DESTINATION = "Destination";
 
-    private Stack<OverthereFile> dstDirStack = new Stack<OverthereFile>();
+    private Stack<OverthereFile> dstDirStack = new Stack<>();
     private OverthereFile srcDir;
 
     protected OverthereFileTransmitter() {

--- a/src/main/java/com/xebialabs/overthere/winrm/KerberosJaasConfiguration.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/KerberosJaasConfiguration.java
@@ -43,7 +43,7 @@ class KerberosJaasConfiguration extends Configuration {
 
     @Override
     public AppConfigurationEntry[] getAppConfigurationEntry(String s) {
-        final HashMap<String, String> options = new HashMap<String, String>();
+        final HashMap<String, String> options = new HashMap<>();
 
         if (debug) {
             options.put("debug", "true");

--- a/src/main/java/com/xebialabs/overthere/winrm/WinRmClient.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WinRmClient.java
@@ -73,6 +73,7 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.util.Iterator;
 import java.util.List;
@@ -544,7 +545,7 @@ class WinRmClient {
 
         final InputStream is = entity.getContent();
         final Writer writer = new StringWriter();
-        final Reader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+        final Reader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         try {
             int n;
             final char[] buffer = new char[1024];

--- a/src/main/java/com/xebialabs/overthere/winrm/WinRmConnection.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WinRmConnection.java
@@ -26,8 +26,8 @@ import com.xebialabs.overthere.*;
 import com.xebialabs.overthere.cifs.CifsConnectionType;
 import com.xebialabs.overthere.cifs.WinrmHttpsCertificateTrustStrategy;
 import com.xebialabs.overthere.cifs.WinrmHttpsHostnameVerificationStrategy;
-import com.xebialabs.overthere.spi.ProcessConnection;
 import com.xebialabs.overthere.spi.AddressPortMapper;
+import com.xebialabs.overthere.spi.ProcessConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,9 +40,7 @@ import static com.xebialabs.overthere.ConnectionOptions.*;
 import static com.xebialabs.overthere.cifs.CifsConnectionBuilder.*;
 import static com.xebialabs.overthere.cifs.ConnectionValidator.checkIsWindowsHost;
 import static com.xebialabs.overthere.cifs.ConnectionValidator.checkNotOldStyleWindowsDomain;
-import static com.xebialabs.overthere.util.OverthereUtils.checkArgument;
-import static com.xebialabs.overthere.util.OverthereUtils.checkNotNull;
-import static com.xebialabs.overthere.util.OverthereUtils.closeQuietly;
+import static com.xebialabs.overthere.util.OverthereUtils.*;
 import static java.lang.String.format;
 import static java.net.InetSocketAddress.createUnresolved;
 
@@ -114,7 +112,7 @@ public class WinRmConnection implements ProcessConnection {
             winRmClient.createShell();
             final String commandId = winRmClient.executeCommand(cmdString);
 
-            final Exception inputReaderTheaException[] = new Exception[1];
+            final Exception[] inputReaderTheaException = new Exception[1];
             final Thread inputReaderThead = new Thread(format("WinRM input reader for command [%s]", commandId)) {
                 @Override
                 public void run() {
@@ -141,7 +139,7 @@ public class WinRmConnection implements ProcessConnection {
             inputReaderThead.setDaemon(true);
             inputReaderThead.start();
 
-            final Exception outputReaderThreadException[] = new Exception[1];
+            final Exception[] outputReaderThreadException = new Exception[1];
             final Thread outputReaderThread = new Thread(format("WinRM output reader for command [%s]", commandId)) {
                 @Override
                 public void run() {

--- a/src/main/java/com/xebialabs/overthere/winrm/WsmanKerberosSchemeFactory.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WsmanKerberosSchemeFactory.java
@@ -54,12 +54,12 @@ class WsmanKerberosSchemeFactory extends KerberosSchemeFactory {
 
     @Override
     public AuthScheme newInstance(final HttpParams params) {
-        logger.trace("WsmanKerberosSchemeFactory.newInstance invoked for SPN {}/{} (spnPort = {}, stripPort = {})", new Object[] {spnServiceClass, spnHost, spnPort, isStripPort() });
+        logger.trace("WsmanKerberosSchemeFactory.newInstance invoked for SPN {}/{} (spnPort = {}, stripPort = {})", spnServiceClass, spnHost, spnPort, isStripPort());
         return new WsmanKerberosScheme(isStripPort(), spnServiceClass, spnHost, spnPort); }
 
     @Override
     public AuthScheme create(final HttpContext context) {
-        logger.trace("WsmanKerberosSchemeFactory.create invoked for SPN {}/{} (spnPort = {}, stripPort = {})", new Object[] {spnServiceClass, spnHost, spnPort, isStripPort() });
+        logger.trace("WsmanKerberosSchemeFactory.create invoked for SPN {}/{} (spnPort = {}, stripPort = {})", spnServiceClass, spnHost, spnPort, isStripPort());
         return new WsmanKerberosScheme(isStripPort(), spnServiceClass, spnHost, spnPort);
     }
 

--- a/src/main/java/com/xebialabs/overthere/winrm/WsmanSPNegoSchemeFactory.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/WsmanSPNegoSchemeFactory.java
@@ -54,13 +54,13 @@ class WsmanSPNegoSchemeFactory extends SPNegoSchemeFactory {
 
     @Override
     public AuthScheme newInstance(final HttpParams params) {
-        logger.trace("WsmanSPNegoSchemeFactory.newInstance invoked for SPN {}/{} (spnPort = {}, stripPort = {})", new Object[] {spnServiceClass, spnHost, spnPort, isStripPort() });
+        logger.trace("WsmanSPNegoSchemeFactory.newInstance invoked for SPN {}/{} (spnPort = {}, stripPort = {})", spnServiceClass, spnHost, spnPort, isStripPort());
         return new WsmanSPNegoScheme(isStripPort(), spnServiceClass, spnHost, spnPort, useCanonicalHostname);
     }
 
     @Override
     public AuthScheme create(final HttpContext context) {
-        logger.trace("WsmanSPNegoSchemeFactory.create invoked for SPN {}/{} (spnPort = {}, stripPort = {})", new Object[] {spnServiceClass, spnHost, spnPort, isStripPort() });
+        logger.trace("WsmanSPNegoSchemeFactory.create invoked for SPN {}/{} (spnPort = {}, stripPort = {})", spnServiceClass, spnHost, spnPort, isStripPort());
         return new WsmanSPNegoScheme(isStripPort(), spnServiceClass, spnHost, spnPort, useCanonicalHostname);
     }
 

--- a/src/main/java/com/xebialabs/overthere/winrm/soap/OptionSet.java
+++ b/src/main/java/com/xebialabs/overthere/winrm/soap/OptionSet.java
@@ -23,6 +23,7 @@
 package com.xebialabs.overthere.winrm.soap;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -35,10 +36,8 @@ public enum OptionSet {
     private final List<KeyValuePair> keyValuePairs;
 
     OptionSet(KeyValuePair... keyValuePairs) {
-        this.keyValuePairs = new ArrayList<KeyValuePair>();
-        for (KeyValuePair keyValuePair : keyValuePairs) {
-            this.keyValuePairs.add(keyValuePair);
-        }
+        this.keyValuePairs = new ArrayList<>();
+        this.keyValuePairs.addAll(Arrays.asList(keyValuePairs));
     }
 
     public List<KeyValuePair> getKeyValuePairs() {


### PR DESCRIPTION
Minor Code Cleanup:

- Removed explicit Type specification in diamond operator ("<>")
- Clubbed catch blocks
- Organized imports
- Replaced anonymous classes with lambda
- Removed unnecessary array creation for varargs

