### PR TITLE
Update com.hierynomus:sshj to 0.31.0 for better Android support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     compile 'org.slf4j:jcl-over-slf4j:1.7.12'
 
     // SSH
-    compile 'com.hierynomus:sshj:0.27.0'
+    compile 'com.hierynomus:sshj:0.31.0'
     runtime 'com.jcraft:jzlib:1.0.7'
 
     // CIFS

--- a/src/main/java/com/xebialabs/overthere/ssh/SshTunnelConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshTunnelConnection.java
@@ -27,6 +27,7 @@ import com.xebialabs.overthere.spi.AddressPortMapper;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.connection.ConnectionException;
 import net.schmizz.sshj.connection.channel.direct.LocalPortForwarder;
+import net.schmizz.sshj.connection.channel.direct.Parameters;
 import net.schmizz.sshj.connection.channel.direct.Session;
 import net.schmizz.sshj.transport.TransportException;
 import org.slf4j.Logger;
@@ -182,7 +183,7 @@ public class SshTunnelConnection extends SshConnection implements AddressPortMap
 
         @Override
         public void run() {
-            LocalPortForwarder.Parameters params = new LocalPortForwarder.Parameters("localhost", localSocket.getLocalPort(),
+            Parameters params = new Parameters("localhost", localSocket.getLocalPort(),
                     remoteAddress.getHostName(), remoteAddress.getPort());
             forwarder = sshClient.newLocalPortForwarder(params, localSocket);
             try {


### PR DESCRIPTION
Currently Overthere depends on sshj version 0.27.0, which does not properly work on Android devices. These issues have been fixed in sshj 0.31.0. However, Overthere's code is currently not fully compatible with this version.

These changes bump sshj to version 0.31.0 and update the code accordingly. All unit tests pass. With the new version, I managed to get Overthere's SSH running on Android 11.

Best regards
Markus