### PR TITLE
D-35826 : Overthere fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,10 @@ if (!project.gradle.startParameter.taskNames.contains("final")) {
 
 dependencies {
     // General dependencies
-    api 'nl.javadude.scannit:scannit:1.4.1'
+    api ('nl.javadude.scannit:scannit:1.4.1'){
+        exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
+    }
+
     constraints {
         api('org.apache.commons:commons-compress:1.24.0') {
             because 'earlier versions of this transitive dependency of scannit have a vulnerability issue'
@@ -107,7 +110,7 @@ dependencies {
     api 'org.slf4j:jcl-over-slf4j:1.7.36'
 
     // SSH
-    api 'com.hierynomus:sshj:0.33.0'
+    api 'com.hierynomus:sshj:0.38.0'
     implementation 'com.jcraft:jzlib:1.1.3'
 
     // CIFS

--- a/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
+++ b/src/main/java/com/xebialabs/overthere/ssh/SshConnection.java
@@ -37,7 +37,7 @@ import net.schmizz.sshj.transport.TransportException;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
 import net.schmizz.sshj.userauth.keyprovider.FileKeyProvider;
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
-import net.schmizz.sshj.userauth.keyprovider.PKCS5KeyFile;
+import net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile;
 import net.schmizz.sshj.userauth.method.AuthKeyboardInteractive;
 import net.schmizz.sshj.userauth.method.AuthPassword;
 import net.schmizz.sshj.userauth.password.PasswordFinder;
@@ -110,7 +110,7 @@ abstract class SshConnection extends BaseOverthereConnection {
         // PKCS5 is missing from 0.19.0 SSHJ config.
         List<Factory.Named<FileKeyProvider>> current = config.getFileKeyProviderFactories();
         current = new ArrayList<>(current);
-        current.add(new PKCS5KeyFile.Factory());
+        current.add(new PKCS8KeyFile.Factory());
         config.setFileKeyProviderFactories(current);
     }
 


### PR DESCRIPTION
Changed SSHJ version and added PKCS8KeyFile. Excluded bcprov-jdk15on jar

Evidence: 
![image](https://github.com/user-attachments/assets/47f9a30b-f688-4646-b806-8469718923b6)
![image](https://github.com/user-attachments/assets/afe15dc3-dd1f-4623-aa00-fce6f69a563d)
