### PR TITLE
S-114701 Vulnerability Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ dependencies {
     api 'com.jcraft:jsch:0.1.55'
     api 'com.google.apis:google-api-services-compute:v1-rev20231031-2.0.0'
     api 'com.google.auth:google-auth-library-oauth2-http:1.20.0'
-    api 'com.google.cloud:google-cloud-os-login:2.29.0'
+    api 'com.google.cloud:google-cloud-os-login:2.51.0'
 
     // Test dependencies
     testImplementation('com.xebialabs.cloud:overcast:2.5.1') {


### PR DESCRIPTION
Vulnerability is in protobuf-java 3.24.4 which is getting pulled as a transitive dependency of google-cloud-os-login 2.29.0

Hence updating google-cloud-os-login to 2.51.0

Definition of Done - 

- [x] did a local build and validated that the vulnerable jar is not present